### PR TITLE
24 set up the initial version of a ci pipeline

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew build --info
 
       - name: Run E2E Tests
-        run: ./gradlew test
+        run: ./gradlew test -DincludeTags="EndToEndTest"
 
       - name: Upload test results
         if: always()  # Run even if previous steps failed

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,11 +13,6 @@ on:
       - synchronize
     paths:
       - "connector/**"  # Trigger only if changes are made under the 'connector' directory
-  push:
-    branches:
-      - "develop"  # Trigger when changes are pushed to the 'develop' branch (e.g., after a PR is merged)
-    paths:
-      - "connector/**"
   workflow_dispatch:  # Allow manual triggering
 
 jobs:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,0 +1,63 @@
+# This workflow builds the connector project and executes E2E tests using Gradle. It is triggered by pull request
+# openings and synchronization, ensuring that the changes introduced by the PR are validated and do not break the
+# connector's functionality.
+
+name: Connector E2E Tests
+
+on:
+#  pull_request:
+#    branches:
+#      - "develop"
+#    types:
+#      - opened
+#      - synchronize
+#    paths:
+#      - "connector/**"  # Trigger only if changes are made under the 'connector' directory
+  push:
+    branches:
+      - "*"
+#      - "develop"  # Trigger when changes are pushed to the 'develop' branch (e.g., after a PR is merged)
+    paths:
+      - "connector/**"
+  workflow_dispatch:  # Allow manual triggering
+
+
+jobs:
+  build-and-test:
+    name: Build and Test Connector
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./connector  # Set default working directory for all run steps
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 23
+        uses: actions/setup-java@v4
+        with:
+          java-version: '23'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
+
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build --info
+
+      - name: Run E2E Tests
+        run: ./gradlew test
+
+      - name: Upload test results
+        if: always()  # Run even if previous steps failed
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: |
+            connector/build/reports/tests/
+            connector/build/test-results/
+          retention-days: 7

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -8,9 +8,7 @@ on:
   pull_request:
     branches:
       - "develop"
-    types:
-      - opened
-      - synchronize
+    types: [opened, reopened, synchronize]
     paths:
       - "connector/**"
       - "!**.md"

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,12 +12,11 @@ on:
       - opened
       - synchronize
     paths:
-      - "connector/**"  # Trigger only if changes are made under the 'connector' directory
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
-      - "CODEOWNERS"
-      - "LICENSE"
+      - "connector/**"
+      - "!**.md"
+      - "!docs/**"
+      - "!CODEOWNERS"
+      - "!LICENSE"
   workflow_dispatch:  # Allow manual triggering
 
 jobs:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -5,22 +5,20 @@
 name: Connector E2E Tests
 
 on:
-#  pull_request:
-#    branches:
-#      - "develop"
-#    types:
-#      - opened
-#      - synchronize
-#    paths:
-#      - "connector/**"  # Trigger only if changes are made under the 'connector' directory
+  pull_request:
+    branches:
+      - "develop"
+    types:
+      - opened
+      - synchronize
+    paths:
+      - "connector/**"  # Trigger only if changes are made under the 'connector' directory
   push:
     branches:
-      - "*"
-#      - "develop"  # Trigger when changes are pushed to the 'develop' branch (e.g., after a PR is merged)
+      - "develop"  # Trigger when changes are pushed to the 'develop' branch (e.g., after a PR is merged)
     paths:
       - "connector/**"
   workflow_dispatch:  # Allow manual triggering
-
 
 jobs:
   build-and-test:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -13,6 +13,11 @@ on:
       - synchronize
     paths:
       - "connector/**"  # Trigger only if changes are made under the 'connector' directory
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "CODEOWNERS"
+      - "LICENSE"
   workflow_dispatch:  # Allow manual triggering
 
 jobs:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -2,7 +2,7 @@
 # openings and synchronization, ensuring that the changes introduced by the PR are validated and do not break the
 # connector's functionality.
 
-name: Connector E2E Tests
+name: Connector PR Validation
 
 on:
   pull_request:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -39,7 +39,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@af1da67850ed9a4cedd57bfd976089dd991e2582
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Build with Gradle Wrapper
         run: ./gradlew build --info


### PR DESCRIPTION
Set up the initial version of a CI pipeline to run E2E tests in each PR opened or synchronized and save the test results:
It is triggered by pull request openings and synchronization, ensuring that the changes introduced by the PR are validated and do not break the connector's functionality.