### PR TITLE
ci: fix permissions id-token

### DIFF
--- a/.github/workflows/connector-build.yml
+++ b/.github/workflows/connector-build.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   AWS_REGION: us-east-1
+  AWS_OIDC_ROLE_TO_ASSUME: arn:aws:iam::605134435349:role/github-actions-assume-role
 
 jobs:
   build-push-connector:
@@ -23,6 +24,7 @@ jobs:
 
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout code
@@ -35,7 +37,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: arn:aws:iam::605134435349:role/github-actions-assume-role
+          role-to-assume: ${{ env.AWS_OIDC_ROLE_TO_ASSUME }}
           role-session-name: github-actions-assume-role
           aws-region: ${{ env.AWS_REGION }}
 

--- a/.github/workflows/connector-pr-validation.yml
+++ b/.github/workflows/connector-pr-validation.yml
@@ -1,7 +1,3 @@
-# This workflow builds the connector project and executes E2E tests using Gradle. It is triggered by pull request
-# openings and synchronization, ensuring that the changes introduced by the PR are validated and do not break the
-# connector's functionality.
-
 name: Connector PR Validation
 
 on:


### PR DESCRIPTION
- Fix permissions for id-token.
- Move role-to-assume to the env block for OIDC authentication.