### PR TITLE
ci: fix code coverage generation

### DIFF
--- a/.github/workflows/connector-pr-validation.yml
+++ b/.github/workflows/connector-pr-validation.yml
@@ -70,13 +70,13 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
 
+      - name: Run E2E Tests
+        run: ./gradlew test -DincludeTags="EndToEndTest" --stacktrace
+
       - name: SonarQube Analysis
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: ./gradlew sonar --info --no-build-cache --stacktrace
-
-      - name: Run E2E Tests
-        run: ./gradlew test -DincludeTags="EndToEndTest" --stacktrace
 
       - name: Publish E2E Tests Results
         uses: dorny/test-reporter@v1


### PR DESCRIPTION
## Description

Put SonarCloud step after Gradle tests to generate a test report that will be used by SonarCloud to display test coverage. This will fix the issue after adding the Jacoco plugin in the pull request: https://github.com/OAEBUDT/oaebudt-dataspace/pull/39
