### PR TITLE
Fix issue with end to end test runtime

### DIFF
--- a/connector/gradle/libs.versions.toml
+++ b/connector/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ nimbus-oauth2-oidc = "11.3"
 testcontainers-keycloak = "3.4.0"
 mockito = "5.16.0"
 jacoco = "0.8.12"
+postgres = "42.7.5"
 
 [libraries]
 # upstream EDC dependencies
@@ -20,6 +21,7 @@ edc-core-spi = { module = "org.eclipse.edc:core-spi", version.ref = "edc" }
 edc-auth-spi = { module = "org.eclipse.edc:auth-spi", version.ref = "edc" }
 nimbus-jose-jwt = { module = "com.nimbusds:nimbus-jose-jwt", version.ref = "nimbus-jwt"}
 nimbus-oauth2-oidc = { module = "com.nimbusds:oauth2-oidc-sdk", version.ref = "nimbus-oauth2-oidc"}
+postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 
 #Federated catalog modules
 edc-fc-core = { module = "org.eclipse.edc:federated-catalog-core", version.ref = "edc" }

--- a/connector/tests/build.gradle.kts
+++ b/connector/tests/build.gradle.kts
@@ -18,7 +18,7 @@ dependencies {
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.hashicorp.vault)
     testImplementation(libs.testcontainers.keycloak)
-    testFixturesImplementation(libs.postgres)
+    testImplementation(libs.postgres)
 
     testCompileOnly(project(":launchers:runtime-embedded"))
 }

--- a/connector/tests/build.gradle.kts
+++ b/connector/tests/build.gradle.kts
@@ -1,3 +1,8 @@
+plugins {
+    `java-library`
+    `java-test-fixtures`
+}
+
 
 dependencies {
     testImplementation(libs.edc.boot.lib)
@@ -13,7 +18,7 @@ dependencies {
     testImplementation(libs.testcontainers.postgresql)
     testImplementation(libs.testcontainers.hashicorp.vault)
     testImplementation(libs.testcontainers.keycloak)
+    testFixturesImplementation(libs.postgres)
 
-    testImplementation(project(":extensions:keycloak-auth"))
-    testRuntimeOnly(project(":launchers:runtime-embedded"))
+    testCompileOnly(project(":launchers:runtime-embedded"))
 }

--- a/connector/tests/src/test/java/org/oaebudt/edc/ManagementApiTransferTest.java
+++ b/connector/tests/src/test/java/org/oaebudt/edc/ManagementApiTransferTest.java
@@ -26,7 +26,6 @@ import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
-import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
@@ -45,7 +44,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @EndToEndTest
-@PostgresqlIntegrationTest
 class ManagementApiTransferTest {
 
     public static final String DCAT_TYPE = "[0].@type";

--- a/connector/tests/src/test/java/org/oaebudt/edc/ManagementApiTransferTest.java
+++ b/connector/tests/src/test/java/org/oaebudt/edc/ManagementApiTransferTest.java
@@ -20,13 +20,13 @@ import jakarta.json.Json;
 import jakarta.json.JsonArrayBuilder;
 import jakarta.json.JsonObject;
 import java.io.IOException;
-import java.time.Duration;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import org.assertj.core.api.Assertions;
 import org.eclipse.edc.connector.controlplane.test.system.utils.PolicyFixtures;
 import org.eclipse.edc.junit.annotations.EndToEndTest;
+import org.eclipse.edc.junit.annotations.PostgresqlIntegrationTest;
 import org.eclipse.edc.junit.extensions.EmbeddedRuntime;
 import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockserver.integration.ClientAndServer;
-import org.oaebudt.edc.keycloak.KeyCloakAuthenticationExtension;
 import org.oaebudt.edc.utils.HashiCorpVaultEndToEndExtension;
 import org.oaebudt.edc.utils.KeycloakEndToEndExtension;
 import org.oaebudt.edc.utils.OaebudtParticipant;
@@ -46,13 +45,14 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 @EndToEndTest
+@PostgresqlIntegrationTest
 class ManagementApiTransferTest {
 
     public static final String DCAT_TYPE = "[0].@type";
     public static final String CATALOG = "dcat:Catalog";
     public static final String DATASET_ASSET_ID = "[0].'dcat:dataset'.@id";
 
-    private static final String CONNECTOR_MODULE_PATH = ":launcher:runtime-embedded";
+    private static final String CONNECTOR_MODULE_PATH = ":launchers:runtime-embedded";
 
     private static final OaebudtParticipant PROVIDER = OaebudtParticipant.Builder.newInstance()
             .id("provider").name("provider")
@@ -101,8 +101,7 @@ class ManagementApiTransferTest {
                 .configurationProvider(CONSUMER::getConfiguration)
                 .configurationProvider(() -> CONSUMER_POSTGRESQL_EXTENSION.configFor(CONSUMER.getName()))
                 .configurationProvider(VAULT_EXTENSION::config)
-                .configurationProvider(KEYCLOAK_EXTENSION::config)
-                .registerSystemExtension(ServiceExtension.class, new KeyCloakAuthenticationExtension()));
+                .configurationProvider(KEYCLOAK_EXTENSION::config));
 
     @RegisterExtension
     protected static RuntimeExtension provider = new RuntimePerClassExtension(
@@ -111,7 +110,6 @@ class ManagementApiTransferTest {
                     .configurationProvider(() -> PROVIDER_POSTGRESQL_EXTENSION.configFor(PROVIDER.getName()))
                     .configurationProvider(VAULT_EXTENSION::config)
                     .configurationProvider(KEYCLOAK_EXTENSION::config)
-                    .registerSystemExtension(ServiceExtension.class, new KeyCloakAuthenticationExtension())
                     .registerSystemExtension(ServiceExtension.class, PROVIDER.seedVaultKeys()));
 
     @RegisterExtension
@@ -120,8 +118,7 @@ class ManagementApiTransferTest {
                     .configurationProvider(PROVIDER_FC::getConfiguration)
                     .configurationProvider(() -> PROVIDER_FC_POSTGRESQL_EXTENSION.configFor(PROVIDER_FC.getName()))
                     .configurationProvider(VAULT_EXTENSION::config)
-                    .configurationProvider(KEYCLOAK_EXTENSION::config)
-                    .registerSystemExtension(ServiceExtension.class, new KeyCloakAuthenticationExtension()));
+                    .configurationProvider(KEYCLOAK_EXTENSION::config));
 
     @Test
     public void shouldSupportPushTransfer() {


### PR DESCRIPTION
## Description

Initially, the end to end test dependencies were not imported correctly
This issue led to finding it difficult to start two different runtimes while working on the Identity hub.
The issue should fix this so it can enable to start both connector and Identity hub runtimes

## Issue
Fixes #65 
