### PR TITLE
define e2e test order to fix issue with federated catalog test

### DIFF
--- a/connector/tests/src/test/java/org/oaebudt/edc/ManagementApiTransferTest.java
+++ b/connector/tests/src/test/java/org/oaebudt/edc/ManagementApiTransferTest.java
@@ -175,6 +175,7 @@ class ManagementApiTransferTest {
         createIdentityHubParticipant(IDENTITY_HUB_CONSUMER, consumerManifest, OaebudtParticipant.IH_API_SUPERUSER_KEY);
     }
 
+    @Order(13)
     @Test
     public void shouldSupportPushTransfer() {
         PROVIDER.setAuthorizationToken(KEYCLOAK_EXTENSION.getToken());
@@ -253,6 +254,7 @@ class ManagementApiTransferTest {
 
     }
 
+    @Order(14)
     @Test
     public void shouldGetContractOfferViaFederatedCatalog() {
         PROVIDER.setAuthorizationToken(KEYCLOAK_EXTENSION.getToken());


### PR DESCRIPTION
## Description

define e2e test order to fix issue with federated catalog test
It makes sure the federated catalog test runs first so we can have an empty catalog at the point of testing
The fc test defines a `.body(DATASET_ASSET_ID, hasItem(assetId)));` It expects the catalog to have a list of item.
But in some cases, the federated catalog test runs first and the catalog at the point of test does not contain a list. It contains a string. 
ordering fixes this

