### PR TITLE
78 task develop a helm charts connector and issuer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,9 @@ repos:
       rev: v2.3.0
       hooks:
         -   id: end-of-file-fixer
+  - repo: https://github.com/norwoodj/helm-docs
+    rev:  ""
+    hooks:
+      - id: helm-docs
+        args:
+          - --chart-search-root=connector/charts/oaebudt-connector

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,3 @@ repos:
       rev: v2.3.0
       hooks:
         -   id: end-of-file-fixer
-  - repo: https://github.com/norwoodj/helm-docs
-    rev:  ""
-    hooks:
-      - id: helm-docs
-        args:
-          - --chart-search-root=connector/charts/oaebudt-connector

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,4 +8,4 @@ repos:
     hooks:
       - id: helm-docs
         args:
-          - --chart-search-root=connector/charts/oaebudt-connector
+          - --chart-search-root=connector/charts

--- a/connector/charts/oaebudt-connector/.helmignore
+++ b/connector/charts/oaebudt-connector/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/connector/charts/oaebudt-connector/Chart.lock
+++ b/connector/charts/oaebudt-connector/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: postgresql
+  repository: oci://registry-1.docker.io/bitnamicharts
+  version: 16.6.3
+- name: vault
+  repository: https://helm.releases.hashicorp.com
+  version: 0.30.0
+digest: sha256:21c60afceee3dfad507b34b0e5bd8ac9d2a14800206273878692da62eb133e55
+generated: "2025-04-16T14:38:22.212378+01:00"

--- a/connector/charts/oaebudt-connector/Chart.yaml
+++ b/connector/charts/oaebudt-connector/Chart.yaml
@@ -1,0 +1,29 @@
+apiVersion: v2
+name: oaebudt-connector
+description: A Helm chart for deploying a proof-of-concept (PoC) Data Space Connector, including its dependencies, 
+  based on Eclipse EDC and supporting the Open Access EBook Usage Data Trust (OAEBUDT) initiative.
+  The deployment consists of a single runtime that includes a Control Plane, Data Plane, Identity Hub, Federated Catalog, 
+  and a Web API component. The Web API extends the business logic to support the OAEBUDT eBook context.
+  This chart is designed to work with an existing PostgreSQL database and an existing HashiCorp Vault instance.
+type: application
+version: 0.1.0
+appVersion: "1.16.0"
+home: https://github.com/OAEBUDT/oaebudt-dataspace/tree/develop/connector/charts/oaebudt-connector
+sources:
+  - https://github.com/OAEBUDT/oaebudt-dataspace/tree/develop/connector/charts/oaebudt-connector
+maintainers:
+  - name: Mohamed Khalil BELDI
+    email: mohamedkhalilbeldi@think-it.io
+dependencies:
+  # PostgreSQL
+  - name: postgresql
+    alias: postgresql
+    version: "16.6.3"
+    repository: oci://registry-1.docker.io/bitnamicharts
+    condition: postgresql.install
+  # HashiCorp Vault
+  - name: vault
+    alias: vault
+    version: "0.30.0"
+    repository: https://helm.releases.hashicorp.com
+    condition: vault.install

--- a/connector/charts/oaebudt-connector/README.md
+++ b/connector/charts/oaebudt-connector/README.md
@@ -1,0 +1,1 @@
+# connector

--- a/connector/charts/oaebudt-connector/README.md
+++ b/connector/charts/oaebudt-connector/README.md
@@ -1,1 +1,132 @@
-# connector
+# oaebudt-connector
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+
+A Helm chart for deploying a proof-of-concept (PoC) Data Space Connector, including its dependencies, based on Eclipse EDC and supporting the Open Access EBook Usage Data Trust (OAEBUDT) initiative. The deployment consists of a single runtime that includes a Control Plane, Data Plane, Identity Hub, Federated Catalog, and a Web API component. The Web API extends the business logic to support the OAEBUDT eBook context. This chart is designed to work with an existing PostgreSQL database and an existing HashiCorp Vault instance.
+
+**Homepage:** <https://github.com/OAEBUDT/oaebudt-dataspace/tree/develop/connector/charts/oaebudt-connector>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Mohamed Khalil BELDI | <mohamedkhalilbeldi@think-it.io> |  |
+
+## Source Code
+
+* <https://github.com/OAEBUDT/oaebudt-dataspace/tree/develop/connector/charts/oaebudt-connector>
+
+## Requirements
+
+| Repository | Name | Version |
+|------------|------|---------|
+| https://helm.releases.hashicorp.com | vault(vault) | 0.30.0 |
+| oci://registry-1.docker.io/bitnamicharts | postgresql(postgresql) | 16.6.3 |
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| autoscaling.enabled | bool | `false` |  |
+| autoscaling.maxReplicas | int | `100` |  |
+| autoscaling.minReplicas | int | `1` |  |
+| autoscaling.targetCPUUtilizationPercentage | int | `80` |  |
+| catalog.crawler.initialDelay | int | `120` | Initial delay for the crawling to start. Leave blank for a random delay |
+| catalog.crawler.targetsFile | string | `"/etc/dataspace/participants.json"` | File path to a JSON file containing TargetNode entries |
+| catalog.nodes | list | `[]` |  |
+| dcp.identityHub.credentials.configMap | string | `"{{ .Values.participant.id | lower }}-credentials"` |  |
+| dcp.identityHub.credentials.mountPath | string | `"/etc/dataspace/did/credentials/{{ .Values.participant.id }}/"` |  |
+| dcp.identityHub.superuserKey | string | `"c3VwZXItdXNlcg==.K+CKuM+8XNuEfLggseLntVljpgLnRzPMNo1WT6dWU1HUJP07l50k8AUreEIy3gcYTBn4vxzMWIg+1TDPYsxpug=="` | Use a base64 key |
+| dcp.tls.enabled | bool | `false` |  |
+| dcp.trustedIssuers | list | `[]` |  |
+| endpoints.catalog.authKey | string | `"password"` |  |
+| endpoints.catalog.path | string | `"/api/catalog"` |  |
+| endpoints.catalog.port | int | `7102` |  |
+| endpoints.control.path | string | `"/api/control"` |  |
+| endpoints.control.port | int | `7103` |  |
+| endpoints.credentials.path | string | `"/api/credentials"` |  |
+| endpoints.credentials.port | int | `6102` |  |
+| endpoints.default.path | string | `"/api"` |  |
+| endpoints.default.port | int | `7100` |  |
+| endpoints.did.path | string | `"/"` |  |
+| endpoints.did.port | int | `80` |  |
+| endpoints.identity.path | string | `"/api/identity"` |  |
+| endpoints.identity.port | int | `6103` |  |
+| endpoints.management.authKey | string | `"password"` |  |
+| endpoints.management.path | string | `"/api/management"` |  |
+| endpoints.management.port | int | `7105` |  |
+| endpoints.presentation.path | string | `"/api/presentation"` |  |
+| endpoints.presentation.port | int | `6104` |  |
+| endpoints.protocol.path | string | `"/api/dsp"` |  |
+| endpoints.protocol.port | int | `7104` |  |
+| endpoints.public.path | string | `"/api/public"` |  |
+| endpoints.public.port | int | `17100` |  |
+| endpoints.sts.path | string | `"/api/sts"` |  |
+| endpoints.sts.port | int | `6106` |  |
+| endpoints.version.path | string | `"/api/version"` |  |
+| endpoints.version.port | int | `7106` |  |
+| fullnameOverride | string | `""` |  |
+| global.domain | string | `""` | Global dataspace domain (required for ingress) |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"605134435349.dkr.ecr.us-east-1.amazonaws.com/oaebudt-dataspace/connector"` |  |
+| image.tag | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | list | `[]` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | string | `"enable"` |  |
+| ingress.tls | list | `[]` |  |
+| livenessProbe.enabled | bool | `true` |  |
+| livenessProbe.failureThreshold | int | `6` |  |
+| livenessProbe.initialDelaySeconds | int | `30` |  |
+| livenessProbe.periodSeconds | int | `10` |  |
+| livenessProbe.successThreshold | int | `1` |  |
+| livenessProbe.timeoutSeconds | int | `5` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| participant.did | string | `""` |  |
+| participant.id | string | `""` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| postgresql.auth.database | string | `"oaebudt_connector"` | Maximum name length is 31 characters by default |
+| postgresql.auth.password | string | `"oaebudt_connector"` |  |
+| postgresql.auth.username | string | `"oaebudt_connector"` | Maximum name length is 31 characters by default |
+| postgresql.install | bool | `true` | Switch to enable or disable the PostgreSQL helm chart |
+| postgresql.schema.autoCreate | bool | `true` | Enable auto-creation of the schema on boot |
+| readinessProbe.enabled | bool | `true` |  |
+| readinessProbe.failureThreshold | int | `6` |  |
+| readinessProbe.initialDelaySeconds | int | `30` |  |
+| readinessProbe.periodSeconds | int | `10` |  |
+| readinessProbe.successThreshold | int | `1` |  |
+| readinessProbe.timeoutSeconds | int | `5` |  |
+| replicaCount | int | `1` |  |
+| resources.limits.cpu | float | `1.5` |  |
+| resources.limits.memory | string | `"1536Mi"` |  |
+| resources.requests.cpu | string | `"500m"` |  |
+| resources.requests.memory | string | `"1024Mi"` |  |
+| securityContext | object | `{}` |  |
+| service.annotations | object | `{}` |  |
+| service.labels | object | `{}` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automount | bool | `true` |  |
+| serviceAccount.create | bool | `false` |  |
+| serviceAccount.imagePullSecrets | list | `[]` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |
+| vault.hashicorp.healthCheck.enabled | bool | `true` |  |
+| vault.hashicorp.healthCheck.standbyOk | bool | `true` |  |
+| vault.hashicorp.paths.folder | string | `""` |  |
+| vault.hashicorp.paths.health | string | `"/v1/sys/health"` |  |
+| vault.hashicorp.paths.secret | string | `"/v1/secret"` |  |
+| vault.hashicorp.timeout | int | `30` |  |
+| vault.hashicorp.tokenSecret | string | `"{{ .Release.Name }}-vault-token"` |  |
+| vault.hashicorp.tokenSecretKey | string | `"root-token"` |  |
+| vault.hashicorp.url | string | `"http://{{ .Release.Name }}-vault:8200"` |  |
+| vault.injector.enabled | bool | `false` |  |
+| vault.install | bool | `true` | Switch to enable or disable the HashiCorp Vault helm chart |
+| vault.server.standalone.enabled | bool | `true` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/connector/charts/oaebudt-connector/credentials/participant-a/dataprocessor-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-a/dataprocessor-credential.json
@@ -1,0 +1,39 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1ca7",
+  "participantContextId": "did:web:did.participant-a.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-a.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "format": "VC1_0_JWT",
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtYS5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWEuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9kcy1vYWVidWR0L2NyZWRlbnRpYWxzLyIsImNvbnRyYWN0VmVyc2lvbiI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6Y29udHJhY3RWZXJzaW9uIiwibGV2ZWwiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOmxldmVsIn1dLCJpZCI6Imh0dHBzOi8vZHMub2FlYnVkdC50aGluay1pdC5pby9jcmVkZW50aWFscy9qc3Rvci8xMjM0NSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8jRGF0YVByb2Nlc3NvckNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjppc3N1ZXIub2FlYnVkdC5zdmMuY2x1c3Rlci5sb2NhbCIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDgtMThUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6d2ViOmRpZC5wYXJ0aWNpcGFudC1hLnN2Yy5jbHVzdGVyLmxvY2FsIiwibGV2ZWwiOiJwcm9jZXNzaW5nIiwiY29udHJhY3RWZXJzaW9uIjoiMS4wLjAifX0sImlhdCI6MTc0NDYzMDczNn0.ndRZMgpcUM1F3z7yizPds7g1q0paeoYhmmKaOXeQGrHxxru0DFhjLchPW1RjlFZPkgXXjRhfxvyLjDGvA2M_Aw",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "id": "did:web:did.participant-a.svc.cluster.local",
+            "contractVersion": "1.0.0",
+            "level": "processing"
+          }
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/jstor/12345",
+      "type": [
+        "VerifiableCredential",
+        "DataProcessorCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-a/membership-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-a/membership-credential.json
@@ -1,0 +1,43 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1b14",
+  "participantContextId": "did:web:did.participant-a.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-a.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtYS5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWEuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9kcy1vYWVidWR0L2NyZWRlbnRpYWxzLyIsIm1lbWJlcnNoaXAiOiJkcy1vYWVidWR0Om1lbWJlcnNoaXAiLCJtZW1iZXJzaGlwVHlwZSI6ImRzLW9hZWJ1ZHQ6bWVtYmVyc2hpcFR5cGUiLCJ3ZWJzaXRlIjoiZHMtb2FlYnVkdDp3ZWJzaXRlIiwiY29udGFjdCI6ImRzLW9hZWJ1ZHQ6Y29udGFjdCIsInNpbmNlIjoiZHMtb2FlYnVkdDpzaW5jZSJ9XSwiaWQiOiJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8vY3JlZGVudGlhbHMvanN0b3IvMTIzNCIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8jTWVtYmVyc2hpcENyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjppc3N1ZXIub2FlYnVkdC5zdmMuY2x1c3Rlci5sb2NhbCIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDgtMThUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6d2ViOmRpZC5wYXJ0aWNpcGFudC1hLnN2Yy5jbHVzdGVyLmxvY2FsIiwibWVtYmVyc2hpcCI6eyJtZW1iZXJzaGlwVHlwZSI6IlByb3NwZWN0TWVtYmVyIiwid2Vic2l0ZSI6Imh0dHBzOi8vd3d3LmpzdG9yLm9yZyIsImNvbnRhY3QiOiJKYXlzaHJlZS5CaGFrdGFAaXRoYWthLm9yZyIsInNpbmNlIjoiMjAyMy0wMS0wMVQwMDowMDowMFoifX19LCJpYXQiOjE3NDQ2MzA3MzV9.-dQ9vM3MORwYby5g1CpNcFWKF9V3w4KX81wf80sBWTHfD1dU5whNNCXUYoj3OCMa-N0zPUHj36ER6MWpCFGyDw",
+    "format": "VC1_0_JWT",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "membership": {
+              "contact": "Jayshree.Bhakta@ithaka.org",
+              "membershipType": "PartialMember",
+              "since": "2023-01-01T00:00:00Z",
+              "website": "https://www.jstor.org"
+            }
+          },
+          "id": "did:web:did.participant-a.svc.cluster.local"
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/jstor/1234",
+      "type": [
+        "VerifiableCredential",
+        "MembershipCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-b/dataprocessor-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-b/dataprocessor-credential.json
@@ -1,0 +1,39 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1b15",
+  "participantContextId": "did:web:did.participant-b.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-b.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "format": "VC1_0_JWT",
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtYi5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWIuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9tdmQvY3JlZGVudGlhbHMvIiwiY29udHJhY3RWZXJzaW9uIjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczpjb250cmFjdFZlcnNpb24iLCJsZXZlbCI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6bGV2ZWwifV0sImlkIjoiaHR0cHM6Ly9kcy5vYWVidWR0LnRoaW5rLWl0LmlvL2NyZWRlbnRpYWxzL2xpYmx5bngvMTIzNDUiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiaHR0cHM6Ly9kcy5vYWVidWR0LnRoaW5rLWl0LmlvI0RhdGFQcm9jZXNzb3JDcmVkZW50aWFsIl0sImlzc3VlciI6ImRpZDp3ZWI6aXNzdWVyLm9hZWJ1ZHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJpc3N1YW5jZURhdGUiOiIyMDIzLTA4LTE4VDAwOjAwOjAwWiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtYi5zdmMuY2x1c3Rlci5sb2NhbCIsImNvbnRyYWN0VmVyc2lvbiI6IjEuMC4wIiwibGV2ZWwiOiJwcm9jZXNzaW5nIn19LCJpYXQiOjE3NDQ2MzA3MzZ9.vNA9-CVYpj0YwyZE5P_w3iXTxrg38YOX3mOTa_qlM5XggwEbWHWsbTwaF8m84TLTKgGRC8BZQfqEIW6GrGOACg",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "id": "did:web:did.participant-b.svc.cluster.local",
+            "contractVersion": "1.0.0",
+            "level": "processing"
+          }
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/liblynx/12345",
+      "type": [
+        "VerifiableCredential",
+        "DataProcessorCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-b/membership-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-b/membership-credential.json
@@ -1,0 +1,41 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1b14",
+  "participantContextId": "did:web:did.participant-b.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-b.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtYi5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWIuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9tdmQvY3JlZGVudGlhbHMvIiwibWVtYmVyc2hpcCI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6bWVtYmVyc2hpcCIsIm1lbWJlcnNoaXBUeXBlIjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczptZW1iZXJzaGlwVHlwZSIsIndlYnNpdGUiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOndlYnNpdGUiLCJjb250YWN0IjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczpjb250YWN0Iiwic2luY2UiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOnNpbmNlIn1dLCJpZCI6Imh0dHBzOi8vZHMub2FlYnVkdC50aGluay1pdC5pby9jcmVkZW50aWFscy9saWJseW54LzEyMzQiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiaHR0cHM6Ly9kcy5vYWVidWR0LnRoaW5rLWl0LmlvI01lbWJlcnNoaXBDcmVkZW50aWFsIl0sImlzc3VlciI6ImRpZDp3ZWI6aXNzdWVyLm9hZWJ1ZHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJpc3N1YW5jZURhdGUiOiIyMDIzLTA4LTE4VDAwOjAwOjAwWiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtYi5zdmMuY2x1c3Rlci5sb2NhbCIsIm1lbWJlcnNoaXAiOnsibWVtYmVyc2hpcFR5cGUiOiJGdWxsTWVtYmVyIiwid2Vic2l0ZSI6Ind3dy5saWJseW54LmNvbSIsImNvbnRhY3QiOiJtaWNoZWxsZUBsaWJseW54LmNvbSIsInNpbmNlIjoiMjAyMy0wMS0wMVQwMDowMDowMFoifX19LCJpYXQiOjE3NDQ2MzA3MzZ9.q5wfQuVdlRqZ2T79lCvCcmRGZ6V3DT0FLIqVYJ9YpYxQ2m_zAg7SQT_FIYaDjQpGQ6OhkIKH6DZxs3xgmETOCA",
+    "format": "VC1_0_JWT",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "membershipType": "FullMember",
+            "website": "www.liblynx.com",
+            "contact": "michelle@liblynx.com",
+            "since": "2023-01-01T00:00:00Z"
+          },
+          "id": "did:web:did.participant-b.svc.cluster.local"
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/liblynx/1234",
+      "type": [
+        "VerifiableCredential",
+        "MembershipCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-c/dataprocessor-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-c/dataprocessor-credential.json
@@ -1,0 +1,39 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1cc7",
+  "participantContextId": "did:web:did.participant-c.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-c.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "format": "VC1_0_JWT",
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtYy5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWMuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9kcy1vYWVidWR0L2NyZWRlbnRpYWxzLyIsImNvbnRyYWN0VmVyc2lvbiI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6Y29udHJhY3RWZXJzaW9uIiwibGV2ZWwiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOmxldmVsIn1dLCJpZCI6Imh0dHBzOi8vZHMub2FlYnVkdC50aGluay1pdC5pby9jcmVkZW50aWFscy9taWNoaWdhbi8xMjM0NSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8jRGF0YVByb2Nlc3NvckNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjppc3N1ZXIub2FlYnVkdC5zdmMuY2x1c3Rlci5sb2NhbCIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDgtMThUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6d2ViOmRpZC5wYXJ0aWNpcGFudC1jLnN2Yy5jbHVzdGVyLmxvY2FsIiwibGV2ZWwiOiJwcm9jZXNzaW5nIiwiY29udHJhY3RWZXJzaW9uIjoiMS4wLjAifX0sImlhdCI6MTc0NDk3MTM0N30.QZe8vxvHgJOpy2-li84JIJMBhVP_cdOP-chpUBgph9mgSbMYpACr2utKQkIIVcgaPkm-Dss6q-NVoP4ss1V7Dg",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "id": "did:web:did.participant-c.svc.cluster.local",
+            "contractVersion": "1.0.0",
+            "level": "processing"
+          }
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/michigan/12345",
+      "type": [
+        "VerifiableCredential",
+        "DataProcessorCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-c/membership-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-c/membership-credential.json
@@ -1,0 +1,43 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1c14",
+  "participantContextId": "did:web:did.participant-c.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-c.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtYy5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWMuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9kcy1vYWVidWR0L2NyZWRlbnRpYWxzLyIsIm1lbWJlcnNoaXAiOiJkcy1vYWVidWR0Om1lbWJlcnNoaXAiLCJtZW1iZXJzaGlwVHlwZSI6ImRzLW9hZWJ1ZHQ6bWVtYmVyc2hpcFR5cGUiLCJ3ZWJzaXRlIjoiZHMtb2FlYnVkdDp3ZWJzaXRlIiwiY29udGFjdCI6ImRzLW9hZWJ1ZHQ6Y29udGFjdCIsInNpbmNlIjoiZHMtb2FlYnVkdDpzaW5jZSJ9XSwiaWQiOiJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8vY3JlZGVudGlhbHMvbWljaGlnYW4vMTIzNCIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8jTWVtYmVyc2hpcENyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjppc3N1ZXIub2FlYnVkdC5zdmMuY2x1c3Rlci5sb2NhbCIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDgtMThUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6d2ViOmRpZC5wYXJ0aWNpcGFudC1jLnN2Yy5jbHVzdGVyLmxvY2FsIiwibWVtYmVyc2hpcCI6eyJtZW1iZXJzaGlwVHlwZSI6IlByb3NwZWN0TWVtYmVyIiwid2Vic2l0ZSI6Ind3dy5wdWJsaXNoaW5nLnVtaWNoLmVkdSIsImNvbnRhY3QiOiJqZ21vcnNlQHVtaWNoLmVkdSIsInNpbmNlIjoiMjAyMy0wMS0wMVQwMDowMDowMFoifX19LCJpYXQiOjE3NDQ5NzEzNDV9._SJ7ZSSGNAXAst47uwBplGNk46JoQEPM9hHzNZ-YNfo6mftOfiAsE3iu_P_L3RFFsCBfMDvTt_ylIkbpETUOCQ",
+    "format": "VC1_0_JWT",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "membership": {
+              "membershipType": "ProspectMember",
+              "website": "www.publishing.umich.edu",
+              "contact": "jgmorse@umich.edu",
+              "since": "2023-01-01T00:00:00Z"
+            }
+          },
+          "id": "did:web:did.participant-c.svc.cluster.local"
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/michigan/1234",
+      "type": [
+        "VerifiableCredential",
+        "MembershipCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-d/dataprocessor-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-d/dataprocessor-credential.json
@@ -1,0 +1,39 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1d15",
+  "participantContextId": "did:web:did.participant-d.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-d.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "format": "VC1_0_JWT",
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtZC5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9tdmQvY3JlZGVudGlhbHMvIiwiY29udHJhY3RWZXJzaW9uIjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczpjb250cmFjdFZlcnNpb24iLCJsZXZlbCI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6bGV2ZWwifV0sImlkIjoiaHR0cHM6Ly9kcy5vYWVidWR0LnRoaW5rLWl0LmlvL2NyZWRlbnRpYWxzL3B1bmN0dW1ib29rcy8xMjM0NSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8jRGF0YVByb2Nlc3NvckNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjppc3N1ZXIub2FlYnVkdC5zdmMuY2x1c3Rlci5sb2NhbCIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDgtMThUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6d2ViOmRpZC5wYXJ0aWNpcGFudC1kLnN2Yy5jbHVzdGVyLmxvY2FsIiwiY29udHJhY3RWZXJzaW9uIjoiMS4wLjAiLCJsZXZlbCI6InByb2Nlc3NpbmcifX0sImlhdCI6MTc0NDk3MTM0N30.hU9BXZMw6rQKwo92GNj-bdSc9vlz1-qfXYEjznTBeeY_ma1o4wqqtM_6xPIN9-nWIqBEqcrCL9h8_IkL-gKWDA",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "id": "did:web:did.participant-d.svc.cluster.local",
+            "contractVersion": "1.0.0",
+            "level": "processing"
+          }
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/punctumbooks/12345",
+      "type": [
+        "VerifiableCredential",
+        "DataProcessorCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-d/membership-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-d/membership-credential.json
@@ -1,0 +1,41 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1d14",
+  "participantContextId": "did:web:did.participant-d.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-d.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtZC5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9tdmQvY3JlZGVudGlhbHMvIiwibWVtYmVyc2hpcCI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6bWVtYmVyc2hpcCIsIm1lbWJlcnNoaXBUeXBlIjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczptZW1iZXJzaGlwVHlwZSIsIndlYnNpdGUiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOndlYnNpdGUiLCJjb250YWN0IjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczpjb250YWN0Iiwic2luY2UiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOnNpbmNlIn1dLCJpZCI6Imh0dHBzOi8vZHMub2FlYnVkdC50aGluay1pdC5pby9jcmVkZW50aWFscy9wdW5jdHVtYm9va3MvMTIzNCIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8jTWVtYmVyc2hpcENyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjppc3N1ZXIub2FlYnVkdC5zdmMuY2x1c3Rlci5sb2NhbCIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDgtMThUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6d2ViOmRpZC5wYXJ0aWNpcGFudC1kLnN2Yy5jbHVzdGVyLmxvY2FsIiwibWVtYmVyc2hpcCI6eyJtZW1iZXJzaGlwVHlwZSI6IkZ1bGxNZW1iZXIiLCJ3ZWJzaXRlIjoid3d3LnB1bmN0dW1ib29rcy5jb20iLCJjb250YWN0IjoidmluY2VudEBwdW5jdHVtYm9va3MuY29tIiwic2luY2UiOiIyMDIzLTAxLTAxVDAwOjAwOjAwWiJ9fX0sImlhdCI6MTc0NDk3MTM0N30.--q7zyQUKNooepi8uuYkra5XPxwuXjPDdQUUmfNcY6sWkO3PnvuwEskQ07tlA5LskXyxzdn9CprQQSet15FBBg",
+    "format": "VC1_0_JWT",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "membershipType": "FullMember",
+            "website": "www.punctumbooks.com",
+            "contact": "vincent@punctumbooks.com",
+            "since": "2023-01-01T00:00:00Z"
+          },
+          "id": "did:web:did.participant-d.svc.cluster.local"
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/punctumbooks/1234",
+      "type": [
+        "VerifiableCredential",
+        "MembershipCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-e/dataprocessor-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-e/dataprocessor-credential.json
@@ -1,0 +1,39 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1e15",
+  "participantContextId": "did:web:did.participant-e.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-e.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "format": "VC1_0_JWT",
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtZS5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWUuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9tdmQvY3JlZGVudGlhbHMvIiwiY29udHJhY3RWZXJzaW9uIjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczpjb250cmFjdFZlcnNpb24iLCJsZXZlbCI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6bGV2ZWwifV0sImlkIjoiaHR0cHM6Ly9kcy5vYWVidWR0LnRoaW5rLWl0LmlvL2NyZWRlbnRpYWxzL2tub3dsZWRnZXVubGF0Y2hlZC8xMjM0NSIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8jRGF0YVByb2Nlc3NvckNyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjppc3N1ZXIub2FlYnVkdC5zdmMuY2x1c3Rlci5sb2NhbCIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDgtMThUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6d2ViOmRpZC5wYXJ0aWNpcGFudC1lLnN2Yy5jbHVzdGVyLmxvY2FsIiwiY29udHJhY3RWZXJzaW9uIjoiMS4wLjAiLCJsZXZlbCI6InByb2Nlc3NpbmcifX0sImlhdCI6MTc0NDk3MTM0N30.bM_QK97SqPCqUPKmusrY6knoe61SrOa-0SsVWuz-91crH9L0XfVUQHNxJiaH-YEslnA0kyHz9ENrHmZdTCdTDQ",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "id": "did:web:did.participant-e.svc.cluster.local",
+            "contractVersion": "1.0.0",
+            "level": "processing"
+          }
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/knowledgeunlatched/12345",
+      "type": [
+        "VerifiableCredential",
+        "DataProcessorCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-e/membership-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-e/membership-credential.json
@@ -1,0 +1,41 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1e14",
+  "participantContextId": "did:web:did.participant-e.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-e.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtZS5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWUuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9tdmQvY3JlZGVudGlhbHMvIiwibWVtYmVyc2hpcCI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6bWVtYmVyc2hpcCIsIm1lbWJlcnNoaXBUeXBlIjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczptZW1iZXJzaGlwVHlwZSIsIndlYnNpdGUiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOndlYnNpdGUiLCJjb250YWN0IjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczpjb250YWN0Iiwic2luY2UiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOnNpbmNlIn1dLCJpZCI6Imh0dHBzOi8vZHMub2FlYnVkdC50aGluay1pdC5pby9jcmVkZW50aWFscy9rbm93bGVkZ2V1bmxhdGNoZWQvMTIzNCIsInR5cGUiOlsiVmVyaWZpYWJsZUNyZWRlbnRpYWwiLCJodHRwczovL2RzLm9hZWJ1ZHQudGhpbmstaXQuaW8jTWVtYmVyc2hpcENyZWRlbnRpYWwiXSwiaXNzdWVyIjoiZGlkOndlYjppc3N1ZXIub2FlYnVkdC5zdmMuY2x1c3Rlci5sb2NhbCIsImlzc3VhbmNlRGF0ZSI6IjIwMjMtMDgtMThUMDA6MDA6MDBaIiwiY3JlZGVudGlhbFN1YmplY3QiOnsiaWQiOiJkaWQ6d2ViOmRpZC5wYXJ0aWNpcGFudC1lLnN2Yy5jbHVzdGVyLmxvY2FsIiwibWVtYmVyc2hpcCI6eyJtZW1iZXJzaGlwVHlwZSI6IkZ1bGxNZW1iZXIiLCJ3ZWJzaXRlIjoid3d3Lmtub3dsZWRnZXVubGF0Y2hlZC5vcmciLCJjb250YWN0IjoibWF4QGtub3dsZWRnZXVubGF0Y2hlZC5vcmciLCJzaW5jZSI6IjIwMjMtMDEtMDFUMDA6MDA6MDBaIn19fSwiaWF0IjoxNzQ0OTcxMzQ3fQ.4sq1d8nWgWUhWYVDX1yqbFbolP30ZBrPS90JDyYWkfVrHTxdoTmw_qLFWsoLSQAv08SbgsevN2o7OryVxnycDQ",
+    "format": "VC1_0_JWT",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "membershipType": "FullMember",
+            "website": "www.knowledgeunlatched.org",
+            "contact": "max@knowledgeunlatched.org",
+            "since": "2023-01-01T00:00:00Z"
+          },
+          "id": "did:web:did.participant-e.svc.cluster.local"
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/knowledgeunlatched/1234",
+      "type": [
+        "VerifiableCredential",
+        "MembershipCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-f/dataprocessor-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-f/dataprocessor-credential.json
@@ -1,0 +1,39 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1f15",
+  "participantContextId": "did:web:did.participant-f.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-f.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "format": "VC1_0_JWT",
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtZi5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWYuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9tdmQvY3JlZGVudGlhbHMvIiwiY29udHJhY3RWZXJzaW9uIjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczpjb250cmFjdFZlcnNpb24iLCJsZXZlbCI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6bGV2ZWwifV0sImlkIjoiaHR0cHM6Ly9kcy5vYWVidWR0LnRoaW5rLWl0LmlvL2NyZWRlbnRpYWxzL3ViaXF1aXR5cHJlc3MvMTIzNDUiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiaHR0cHM6Ly9kcy5vYWVidWR0LnRoaW5rLWl0LmlvI0RhdGFQcm9jZXNzb3JDcmVkZW50aWFsIl0sImlzc3VlciI6ImRpZDp3ZWI6aXNzdWVyLm9hZWJ1ZHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJpc3N1YW5jZURhdGUiOiIyMDIzLTA4LTE4VDAwOjAwOjAwWiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtZi5zdmMuY2x1c3Rlci5sb2NhbCIsImNvbnRyYWN0VmVyc2lvbiI6IjEuMC4wIiwibGV2ZWwiOiJwcm9jZXNzaW5nIn19LCJpYXQiOjE3NDQ5NzEzNDd9.iHhOpGY4dgK5Twb7B_3uaHqLnvkmrZRUoPErtm7Yd3ydrbJWULmXcUf9blKiP6Z5RwWNIkknUjtjZZ7B1AzhDQ",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "id": "did:web:did.participant-f.svc.cluster.local",
+            "contractVersion": "1.0.0",
+            "level": "processing"
+          }
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/ubiquitypress/12345",
+      "type": [
+        "VerifiableCredential",
+        "DataProcessorCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/credentials/participant-f/membership-credential.json
+++ b/connector/charts/oaebudt-connector/credentials/participant-f/membership-credential.json
@@ -1,0 +1,41 @@
+{
+  "id": "40e24588-b510-41ca-966c-c1e0f57d1f14",
+  "participantContextId": "did:web:did.participant-f.svc.cluster.local",
+  "timestamp": 1700659822500,
+  "issuerId": "did:web:issuer.oaebudt.svc.cluster.local",
+  "holderId": "did:web:did.participant-f.svc.cluster.local",
+  "state": 500,
+  "issuancePolicy": null,
+  "reissuancePolicy": null,
+  "verifiableCredential": {
+    "rawVc": "eyJraWQiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsI2tleS0xIiwidHlwIjoiSldUIiwiYWxnIjoiRWREU0EifQ.eyJpc3MiOiJkaWQ6d2ViOmlzc3Vlci5vYWVidWR0LnN2Yy5jbHVzdGVyLmxvY2FsIiwiYXVkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtZi5zdmMuY2x1c3Rlci5sb2NhbCIsInN1YiI6ImRpZDp3ZWI6ZGlkLnBhcnRpY2lwYW50LWYuc3ZjLmNsdXN0ZXIubG9jYWwiLCJ2YyI6eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvMjAxOC9jcmVkZW50aWFscy92MSIsImh0dHBzOi8vdzNpZC5vcmcvc2VjdXJpdHkvc3VpdGVzL2p3cy0yMDIwL3YxIiwiaHR0cHM6Ly93d3cudzMub3JnL25zL2RpZC92MSIseyJkcy1vYWVidWR0LWNyZWRlbnRpYWxzIjoiaHR0cHM6Ly93M2lkLm9yZy9tdmQvY3JlZGVudGlhbHMvIiwibWVtYmVyc2hpcCI6ImRzLW9hZWJ1ZHQtY3JlZGVudGlhbHM6bWVtYmVyc2hpcCIsIm1lbWJlcnNoaXBUeXBlIjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczptZW1iZXJzaGlwVHlwZSIsIndlYnNpdGUiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOndlYnNpdGUiLCJjb250YWN0IjoiZHMtb2FlYnVkdC1jcmVkZW50aWFsczpjb250YWN0Iiwic2luY2UiOiJkcy1vYWVidWR0LWNyZWRlbnRpYWxzOnNpbmNlIn1dLCJpZCI6Imh0dHBzOi8vZHMub2FlYnVkdC50aGluay1pdC5pby9jcmVkZW50aWFscy91YmlxdWl0eXByZXNzLzEyMzQiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiaHR0cHM6Ly9kcy5vYWVidWR0LnRoaW5rLWl0LmlvI01lbWJlcnNoaXBDcmVkZW50aWFsIl0sImlzc3VlciI6ImRpZDp3ZWI6aXNzdWVyLm9hZWJ1ZHQuc3ZjLmNsdXN0ZXIubG9jYWwiLCJpc3N1YW5jZURhdGUiOiIyMDIzLTA4LTE4VDAwOjAwOjAwWiIsImNyZWRlbnRpYWxTdWJqZWN0Ijp7ImlkIjoiZGlkOndlYjpkaWQucGFydGljaXBhbnQtZi5zdmMuY2x1c3Rlci5sb2NhbCIsIm1lbWJlcnNoaXAiOnsibWVtYmVyc2hpcFR5cGUiOiJGdWxsTWVtYmVyIiwid2Vic2l0ZSI6Ind3dy51YmlxdWl0eXByZXNzLmNvbSIsImNvbnRhY3QiOiJmcmFuY2VzY28uZGV2aXJnaWxpb0B1YmlxdWl0eXByZXNzLmNvbSIsInNpbmNlIjoiMjAyMy0wMS0wMVQwMDowMDowMFoifX19LCJpYXQiOjE3NDQ5NzEzNDd9.89knTi7q3rSWyPylS-N2QVcCorWtPlQM35yIwsIcSF5kHHtbaeCN2mciRgrwoALDnCHsW8f7N97TGDx5yPbNAQ",
+    "format": "VC1_0_JWT",
+    "credential": {
+      "credentialSubject": [
+        {
+          "claims": {
+            "membershipType": "FullMember",
+            "website": "www.ubiquitypress.com",
+            "contact": "francesco.devirgilio@ubiquitypress.com",
+            "since": "2023-01-01T00:00:00Z"
+          },
+          "id": "did:web:did.participant-f.svc.cluster.local"
+        }
+      ],
+      "id": "https://ds.oaebudt.think-it.io/credentials/ubiquitypress/1234",
+      "type": [
+        "VerifiableCredential",
+        "MembershipCredential"
+      ],
+      "issuer": {
+        "id": "did:web:issuer.oaebudt.svc.cluster.local",
+        "additionalProperties": {}
+      },
+      "issuanceDate": 1702339200.000000000,
+      "expirationDate": null,
+      "credentialStatus": null,
+      "description": null,
+      "name": null
+    }
+  }
+}

--- a/connector/charts/oaebudt-connector/templates/_helpers.tpl
+++ b/connector/charts/oaebudt-connector/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{- define "oaebudt-connector.name" -}}
+{{- default .Chart.Name .Values.nameOverride | replace "+" "_"  | trunc 63 | trimSuffix "-" -}}
+{{- end }}
+
+{{- define "oaebudt-connector.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- define "oaebudt-connector.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "oaebudt-connector.labels" -}}
+helm.sh/chart: {{ include "oaebudt-connector.chart" . }}
+{{ include "oaebudt-connector.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+component: connector
+{{- end }}
+
+{{- define "oaebudt-connector.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "oaebudt-connector.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "oaebudt-connector.serviceaccount.name" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "oaebudt-connector.fullname" . ) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/connector/charts/oaebudt-connector/templates/configmap-credentials.yaml
+++ b/connector/charts/oaebudt-connector/templates/configmap-credentials.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ tpl .Values.dcp.identityHub.credentials.configMap . }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+data:
+  dataprocessor-credential.json: |
+    {{- tpl ($.Files.Get (printf "credentials/%s/dataprocessor-credential.json" .Release.Namespace)) . | nindent 4 }}
+  membership-credential.json: |
+    {{- tpl ($.Files.Get (printf "credentials/%s/membership-credential.json" .Release.Namespace)) . | nindent 4 }}

--- a/connector/charts/oaebudt-connector/templates/configmap-did.yaml
+++ b/connector/charts/oaebudt-connector/templates/configmap-did.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.participant.id }}-did
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+data:
+  did.json: |
+    {
+      "roles":[],
+      "serviceEndpoints":[
+        {
+          "type": "CredentialService",
+          "serviceEndpoint": "{{ printf "http://credentials.%s.svc.cluster.local%s/v1/participants/%s" .Release.Namespace .Values.endpoints.credentials.path (.Values.participant.did | b64enc) }}",
+          "id": "{{ .Values.participant.id }}-credentialservice-1"
+        },
+        {
+          "type": "ProtocolEndpoint",
+          "serviceEndpoint": "{{ printf "http://dsp.%s.svc.cluster.local%s" .Release.Namespace .Values.endpoints.protocol.path }}",
+          "id": "{{ .Values.participant.id }}-dsp"
+        }
+      ],
+      "active": true,
+      "participantId": "{{ .Values.participant.did }}",
+      "did": "{{ .Values.participant.did }}",
+      "key":{
+        "keyId": "{{ .Values.participant.did }}#key-1",
+        "privateKeyAlias": "{{ .Values.participant.did }}#key-1",
+        "keyGeneratorParams":{
+          "algorithm": "EC"
+        }
+      }
+    }

--- a/connector/charts/oaebudt-connector/templates/configmap-participants.yaml
+++ b/connector/charts/oaebudt-connector/templates/configmap-participants.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: catalog-target-nodes
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+data:
+  {{- $targetsFilePath := .Values.catalog.crawler.targetsFile }}
+  {{- $filename := regexReplaceAll "^.*/([^/]+)$" $targetsFilePath "$1" }}
+  {{ $filename }}: |
+    {
+    {{- $length := len .Values.catalog.nodes }}
+    {{- range $index, $participant := .Values.catalog.nodes }}
+      "{{ $participant.name }}": "{{ $participant.did }}"{{- if lt (add $index 1) $length }},{{- end }}
+    {{- end }}
+    }

--- a/connector/charts/oaebudt-connector/templates/deployment.yaml
+++ b/connector/charts/oaebudt-connector/templates/deployment.yaml
@@ -1,0 +1,231 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "oaebudt-connector.fullname" . }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "oaebudt-connector.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "oaebudt-connector.selectorLabels" . | nindent 8 }}
+          {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+          {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "oaebudt-connector.serviceaccount.name" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      # Init container waits for PostgreSQL to be ready before starting the connector container
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox
+          command: [ 'sh', '-c', 'until nc -zv {{ .Release.Name }}-postgresql 5432; do echo waiting for postgres; sleep 2; done' ]
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            ## ID CONFIGURATION ##
+            - name: EDC_HOSTNAME
+              value: {{ .Values.participant.id }}-connector.{{ .Release.Namespace }}.svc.cluster.local
+            - name: EDC_PARTICIPANT_ID
+              value: {{ .Values.participant.did | required ".Values.participant.did is required" | quote }}
+            ## DID TLS CONFIGURATION ##
+            - name: EDC_IAM_DID_WEB_USE_HTTPS
+              value: {{ .Values.dcp.tls.enabled | quote }}
+            ## IAM CONFIGURATION ##
+            - name: EDC_IAM_ISSUER_ID
+              value: {{ printf "did:web:did.%s.svc.cluster.local" .Release.Namespace | quote }}
+            - name: EDC_IH_IAM_ID
+              value: {{ printf "did:web:did.%s.svc.cluster.local" .Release.Namespace | quote }}
+            - name: EDC_IAM_DID_TRUSTED_ISSUERS
+              value: {{ join "," .Values.dcp.trustedIssuers | required "At least one item in .Values.dcp.trustedIssuers is required" | quote }}
+            ## STS CONFIGURATION ##
+            - name: EDC_IAM_STS_PRIVATEKEY_ALIAS
+              value: {{ printf "did:web:did.%s.svc.cluster.local#key-1" .Release.Namespace | quote }}
+            - name: EDC_IAM_STS_PUBLICKEY_ID
+              value: {{ printf "did:web:did.%s.svc.cluster.local#key-1" .Release.Namespace | quote }}
+            - name: EDC_IAM_STS_OAUTH_CLIENT_ID
+              value: {{ printf "did:web:did.%s.svc.cluster.local" .Release.Namespace | quote }}
+            - name: EDC_IAM_STS_OAUTH_CLIENT_SECRET_ALIAS
+              value: {{ printf "did:web:did.%s.svc.cluster.local-sts-client-secret" .Release.Namespace | quote }}
+            - name: EDC_IAM_STS_OAUTH_TOKEN_URL
+              value: {{ printf "http://sts.%s.svc.cluster.local%s/token" .Release.Namespace .Values.endpoints.sts.path | quote }}
+            ## CONTROL PLANE API CONFIGURATION ##
+            - name: WEB_HTTP_PORT
+              value: {{ .Values.endpoints.default.port | quote }}
+            - name: WEB_HTTP_PATH
+              value: {{ .Values.endpoints.default.path | quote }}
+            - name: WEB_HTTP_CATALOG_PORT
+              value: {{ .Values.endpoints.catalog.port | quote }}
+            - name: WEB_HTTP_CATALOG_PATH
+              value: {{ .Values.endpoints.catalog.path | quote }}
+            - name: WEB_HTTP_CATALOG_AUTH_TYPE
+              value: "tokenbased"
+            - name: WEB_HTTP_CATALOG_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: x-api-keys
+                  key: catalog-key
+            - name: WEB_HTTP_CONTROL_PORT
+              value: {{ .Values.endpoints.control.port | quote }}
+            - name: WEB_HTTP_CONTROL_PATH
+              value: {{ .Values.endpoints.control.path | quote }}
+            - name: WEB_HTTP_PROTOCOL_PORT
+              value: {{ .Values.endpoints.protocol.port | quote }}
+            - name: WEB_HTTP_PROTOCOL_PATH
+              value: {{ .Values.endpoints.protocol.path | quote }}
+            - name: WEB_HTTP_MANAGEMENT_PORT
+              value: {{ .Values.endpoints.management.port | quote }}
+            - name: WEB_HTTP_MANAGEMENT_PATH
+              value: {{ .Values.endpoints.management.path | quote }}
+            - name: WEB_HTTP_MANAGEMENT_AUTH_TYPE
+              value: "tokenbased"
+            - name: WEB_HTTP_MANAGEMENT_AUTH_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: x-api-keys
+                  key: management-key
+            - name: WEB_HTTP_VERSION_PORT
+              value: {{ .Values.endpoints.version.port | quote }}
+            - name: WEB_HTTP_VERSION_PATH
+              value: {{ .Values.endpoints.version.path | quote }}
+            ## DSP CONFIGURATION ##
+            - name: EDC_DSP_CALLBACK_ADDRESS
+              value: {{ printf "http://dsp.%s.svc.cluster.local%s" .Release.Namespace .Values.endpoints.protocol.path }}
+            ## Catalog CONFIGURATION ##
+            - name: OAEBUDT_DS_PARTICIPANTS_LIST_FILE
+              value: {{ .Values.catalog.crawler.targetsFile | quote }}
+            - name: EDC_CATALOG_CACHE_EXECUTION_DELAY_SECONDS
+              value: {{ .Values.catalog.crawler.initialDelay | quote }}
+            ## DATA PLANE CONFIGURATION
+            - name: WEB_HTTP_PUBLIC_PORT
+              value: {{ .Values.endpoints.public.port | quote }}
+            - name: WEB_HTTP_PUBLIC_PATH
+              value: {{ .Values.endpoints.public.path | quote }}
+            - name: EDC_TRANSFER_PROXY_TOKEN_VERIFIER_PUBLICKEY_ALIAS
+              value: {{ printf "did:web:did.%s.svc.cluster.local#key-1" .Release.Namespace | quote }}
+            - name: EDC_TRANSFER_PROXY_TOKEN_SIGNER_PRIVATEKEY_ALIAS
+              value: {{ printf "did:web:did.%s.svc.cluster.local#key-1" .Release.Namespace | quote }}
+            - name: EDC_DPF_SELECTOR_URL
+              value: {{ printf "http://dpf.%s.svc.cluster.local%s/v1/dataplanes" .Release.Namespace .Values.endpoints.control.path }}
+            ## IDENTITY HUB API CONFIGURATION ##
+            - name: WEB_HTTP_DID_PORT
+              value: {{ .Values.endpoints.did.port | quote }}
+            - name: WEB_HTTP_DID_PATH
+              value: {{ .Values.endpoints.did.path | quote }}
+            - name: WEB_HTTP_CREDENTIALS_PORT
+              value: {{ .Values.endpoints.credentials.port | quote }}
+            - name: WEB_HTTP_CREDENTIALS_PATH
+              value: {{ .Values.endpoints.credentials.path | quote }}
+            - name: WEB_HTTP_IDENTITY_PORT
+              value: {{ .Values.endpoints.identity.port | quote }}
+            - name: WEB_HTTP_IDENTITY_PATH
+              value: {{ .Values.endpoints.identity.path | quote }}
+            - name: WEB_HTTP_PRESENTATION_PORT
+              value: {{ .Values.endpoints.presentation.port | quote }}
+            - name: WEB_HTTP_PRESENTATION_PATH
+              value: {{ .Values.endpoints.presentation.path | quote }}
+            - name: WEB_HTTP_STS_PORT
+              value: {{ .Values.endpoints.sts.port | quote }}
+            - name: WEB_HTTP_STS_PATH
+              value: {{ .Values.endpoints.sts.path | quote }}
+            ## IDENTITY HUB CONFIGURATION ##
+            - name: EDC_IH_API_SUPERUSER_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: x-api-keys
+                  key: superuser-key
+            - name: EDC_DID_CREDENTIALS_PATH
+              value: {{ tpl .Values.dcp.identityHub.credentials.mountPath . | quote }}
+            ## POSTGRESQL ##
+            - name: "EDC_DATASOURCE_DEFAULT_USER"
+              value: {{ .Values.postgresql.auth.username | required ".Values.postgresql.auth.username is required" | quote }}
+            - name: "EDC_DATASOURCE_DEFAULT_PASSWORD"
+              value: {{ .Values.postgresql.auth.password | required ".Values.postgresql.auth.password is required" | quote }}
+            - name: "EDC_DATASOURCE_DEFAULT_URL"
+              value: {{ printf "jdbc:postgresql://%s-postgresql:5432/%s" .Release.Name .Values.postgresql.auth.database | required ".Values.postgresql.auth.database is required" |quote }}
+            - name: EDC_SQL_SCHEMA_AUTOCREATE
+              value: {{ .Values.postgresql.schema.autoCreate | quote }}
+            ## VAULT ##
+            # see extension https://github.com/eclipse-edc/Connector/tree/main/extensions/common/vault/vault-hashicorp
+            - name: "EDC_VAULT_HASHICORP_URL"
+              value: {{ tpl .Values.vault.hashicorp.url . | quote }}
+            - name: "EDC_VAULT_HASHICORP_TOKEN"
+              value: {{ .Values.vault.hashicorp.token | required ".Values.vault.hashicorp.token is required" | quote }}
+          ports:
+          {{- range $key,$value := .Values.endpoints }}
+            - name: {{ $key }}
+              containerPort: {{ $value.port }}
+              protocol: TCP
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.endpoints.default.path }}/check/liveness
+              port: {{ .Values.endpoints.default.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.endpoints.default.path }}/check/readiness
+              port: {{ .Values.endpoints.default.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: did-credentials
+              mountPath: {{ tpl .Values.dcp.identityHub.credentials.mountPath . }}
+              readOnly: true
+            - name: catalog-target-nodes
+              {{- $targetsFilePath := .Values.catalog.crawler.targetsFile }}
+              {{- $dirPath := regexReplaceAll "/[^/]+$" $targetsFilePath "" }}
+              mountPath: {{ $dirPath }}
+              readOnly: true
+      volumes:
+        - name: did-credentials
+          configMap:
+            name: {{ tpl .Values.dcp.identityHub.credentials.configMap . }}
+        - name: catalog-target-nodes
+          configMap:
+            name: catalog-target-nodes
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/connector/charts/oaebudt-connector/templates/deployment.yaml
+++ b/connector/charts/oaebudt-connector/templates/deployment.yaml
@@ -31,11 +31,30 @@ spec:
       serviceAccountName: {{ include "oaebudt-connector.serviceaccount.name" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      # Init container waits for PostgreSQL to be ready before starting the connector container
+      # Init container waits for PostgreSQL and Vault to be ready before starting the connector container
       initContainers:
-        - name: wait-for-postgres
-          image: busybox
-          command: [ 'sh', '-c', 'until nc -zv {{ .Release.Name }}-postgresql 5432; do echo waiting for postgres; sleep 2; done' ]
+        - name: wait-for-dependencies
+          image: alpine:3.21.3
+          command:
+            - sh
+            - -c
+            - |
+              echo "Installing dependencies..."
+              apk add --no-cache curl netcat-openbsd
+
+              echo "Waiting for PostgreSQL..."
+              until nc -z {{ .Release.Name }}-postgresql 5432; do
+                echo "waiting for postgres...";
+                sleep 2;
+              done
+              echo "PostgreSQL is ready."
+
+              echo "Waiting for Vault to be unsealed..."
+              until curl -s http://{{ .Release.Name }}-vault:8200/v1/sys/health | grep -q '"sealed":false'; do
+                echo "waiting for vault to be unsealed...";
+                sleep 2;
+              done
+              echo "Vault is unsealed."
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -170,7 +189,10 @@ spec:
             - name: "EDC_VAULT_HASHICORP_URL"
               value: {{ tpl .Values.vault.hashicorp.url . | quote }}
             - name: "EDC_VAULT_HASHICORP_TOKEN"
-              value: {{ .Values.vault.hashicorp.token | required ".Values.vault.hashicorp.token is required" | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ tpl .Values.vault.hashicorp.tokenSecret . | quote }}
+                  key: {{ .Values.vault.hashicorp.tokenSecretKey }}
           ports:
           {{- range $key,$value := .Values.endpoints }}
             - name: {{ $key }}

--- a/connector/charts/oaebudt-connector/templates/ingress.yaml
+++ b/connector/charts/oaebudt-connector/templates/ingress.yaml
@@ -1,0 +1,59 @@
+{{- if .Values.ingress.enabled -}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "oaebudt-connector.fullname" . }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  rules:
+    - host: {{ printf "%s.%s" .Release.Name .Values.global.domain | required ".Values.global.domain is required" | quote }}
+      http:
+        paths:
+          - path: {{ .Values.endpoints.management.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.participant.id }}-connector
+                port:
+                  name: management
+          - path: {{ .Values.endpoints.identity.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.participant.id }}-connector
+                port:
+                  name: identity
+          - path: {{ .Values.endpoints.catalog.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.participant.id }}-connector
+                port:
+                  name: catalog
+          - path: {{ .Values.endpoints.public.path }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.participant.id }}-connector
+                port:
+                  name: public
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/connector/charts/oaebudt-connector/templates/job-ih-participant-seed.yaml
+++ b/connector/charts/oaebudt-connector/templates/job-ih-participant-seed.yaml
@@ -11,6 +11,7 @@ spec:
   ttlSecondsAfterFinished: 300
   template:
     metadata:
+      name: identity-hub-create-{{ .Values.participant.id | required "participant.id is required" }}
       labels:
         {{- include "oaebudt-connector.labels" . | nindent 8 }}
     spec:

--- a/connector/charts/oaebudt-connector/templates/job-ih-participant-seed.yaml
+++ b/connector/charts/oaebudt-connector/templates/job-ih-participant-seed.yaml
@@ -1,0 +1,98 @@
+{{- if .Release.IsInstall }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: identity-hub-create-{{ .Values.participant.id | required "participant.id is required" }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 2
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        {{- include "oaebudt-connector.labels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: create-participant
+          image: alpine:3.18
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              echo "Installing required tools..."
+              apk add --no-cache curl jq bash
+
+              export PARTICIPANT_ID={{ .Values.participant.id | quote }}
+              export PARTICIPANT_DID_FILE=/etc/dataspace/{{ .Values.participant.id }}/did.json
+              export IDENTITY_API_KEY={{ .Values.dcp.identityHub.superuserKey | quote }}
+              export IDENTITY_API_URL=http://{{ .Values.participant.id }}-connector:{{ .Values.endpoints.identity.port }}{{ .Values.endpoints.identity.path }}/v1alpha/participants/
+              export CONNECTOR_URL="http://{{ .Values.participant.id }}-connector:{{ .Values.endpoints.default.port }}{{ .Values.endpoints.default.path }}/check/readiness"
+
+              echo "Waiting for connector readiness at $CONNECTOR_URL..."
+              MAX_RETRIES=30
+              COUNT=0
+
+              until wget -q --spider "$CONNECTOR_URL" 2>/dev/null; do
+                COUNT=$((COUNT + 1))
+                if [ "$COUNT" -ge "$MAX_RETRIES" ]; then
+                  echo "Connector failed to become ready after $MAX_RETRIES attempts."
+                  exit 1
+                fi
+                echo "Connector not ready. Retrying in 5s... ($COUNT/$MAX_RETRIES)"
+                sleep 5
+              done
+
+              echo "Connector is ready. Seeding Vault for participant: $PARTICIPANT_ID"
+
+              echo "Load participant did JSON for $PARTICIPANT_ID..."
+
+              export DATA=$(cat $PARTICIPANT_DID_FILE)
+
+              echo "Sending participant creation request to $IDENTITY_API_URL..."
+
+              RESPONSE=$(curl --silent --show-error --location "$IDENTITY_API_URL" \
+                --header 'Content-Type: application/json' \
+                --header "x-api-key: $IDENTITY_API_KEY" \
+                --data "$DATA" \
+                --write-out "HTTPSTATUS:%{http_code}")
+
+              STATUS=$?
+
+              if [ $STATUS -ne 0 ]; then
+                echo "Failed to send participant creation request. curl exited with status $STATUS."
+                exit $STATUS
+              fi
+
+              # Extract the body and the status
+              HTTP_BODY=$(echo "$RESPONSE" | sed -e 's/HTTPSTATUS\:.*//g')
+              HTTP_STATUS=$(echo "$RESPONSE" | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+
+              if [[ "$HTTP_STATUS" =~ ^2 ]]; then
+                echo "Participant creation request sent successfully."
+                echo "Response:"
+                echo "$HTTP_BODY"
+              else
+                echo "Failed: Received HTTP status $HTTP_STATUS"
+                echo "Response:"
+                echo "$HTTP_BODY"
+                exit 1
+              fi
+          resources:
+            limits:
+              cpu: "250m"
+              memory: "128Mi"
+            requests:
+              cpu: "100m"
+              memory: "64Mi"
+          volumeMounts:
+            - name: {{ .Values.participant.id }}-did
+              mountPath: /etc/dataspace/{{ .Values.participant.id }}
+              readOnly: true
+      volumes:
+        - name: {{ .Values.participant.id }}-did
+          configMap:
+            name: {{ .Values.participant.id }}-did
+{{- end }}

--- a/connector/charts/oaebudt-connector/templates/job-vault-init.yaml
+++ b/connector/charts/oaebudt-connector/templates/job-vault-init.yaml
@@ -8,6 +8,7 @@ metadata:
     {{- include "oaebudt-connector.labels" . | nindent 4 }}
 spec:
   backoffLimit: 3
+  ttlSecondsAfterFinished: 300
   template:
     metadata:
       name: {{ .Release.Name }}-vault-init

--- a/connector/charts/oaebudt-connector/templates/job-vault-init.yaml
+++ b/connector/charts/oaebudt-connector/templates/job-vault-init.yaml
@@ -1,0 +1,87 @@
+{{- if .Release.IsInstall }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-vault-init
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: {{ .Release.Name }}-vault-init
+      labels:
+        {{- include "oaebudt-connector.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ .Release.Name }}-vault-init-sa
+      restartPolicy: OnFailure
+      containers:
+        - name: vault-init
+          image: bitnami/kubectl:1.32.3
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -e
+              echo "Installing required tools..."
+              apt-get update && apt-get install -y curl jq unzip
+              curl -o vault.zip https://releases.hashicorp.com/vault/1.19.2/vault_1.19.2_linux_amd64.zip
+              unzip vault.zip && mv vault /usr/local/bin/ && chmod +x /usr/local/bin/vault
+
+              echo "Waiting for Vault to be ready..."
+              until curl -s http://{{ .Release.Name }}-vault:8200/v1/sys/health | grep -q '"initialized":false'; do
+                echo "Vault not ready yet. Retrying in 3s..."
+                sleep 3
+              done
+
+              echo "Initializing Vault..."
+              vault operator init -key-shares=1 -key-threshold=1 -format=json > /tmp/init.json
+
+              UNSEAL_KEY=$(jq -r ".unseal_keys_b64[0]" /tmp/init.json)
+              ROOT_TOKEN=$(jq -r ".root_token" /tmp/init.json)
+
+              echo "Unsealing Vault..."
+              vault operator unseal "$UNSEAL_KEY"
+              echo "Creating a KV secret engine at path=secret..."
+              VAULT_TOKEN=$ROOT_TOKEN vault secrets enable -path=secret -version=2 kv
+
+              echo "Creating Kubernetes Secret with root token..."
+              kubectl create secret generic {{ tpl .Values.vault.hashicorp.tokenSecret . }} \
+                --from-literal={{ .Values.vault.hashicorp.tokenSecretKey }}=$ROOT_TOKEN \
+                --from-literal=unseal-key=$UNSEAL_KEY
+
+              echo "Vault initialized and unsealed successfully"
+              echo "Root token stored in Kubernetes Secret: {{ tpl .Values.vault.hashicorp.tokenSecret . }}"
+          env:
+            - name: VAULT_ADDR
+              value: "http://{{ .Release.Name }}-vault:8200"
+          securityContext:
+            runAsUser: 0
+            allowPrivilegeEscalation: true
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-vault-init-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-vault-init-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-vault-init-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-vault-init-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-vault-init-sa
+{{- end }}

--- a/connector/charts/oaebudt-connector/templates/secret-api-key.yaml
+++ b/connector/charts/oaebudt-connector/templates/secret-api-key.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: x-api-keys
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+data:
+  management-key: {{ .Values.endpoints.management.authKey| b64enc | quote }}
+  catalog-key: {{ .Values.endpoints.catalog.authKey | b64enc | quote }}
+  superuser-key: {{ .Values.dcp.identityHub.superuserKey | b64enc | quote }}

--- a/connector/charts/oaebudt-connector/templates/service-credentials.yaml
+++ b/connector/charts/oaebudt-connector/templates/service-credentials.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: credentials
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 80
+      targetPort: credentials
+      protocol: TCP
+      name: did
+  selector:
+    {{- include "oaebudt-connector.selectorLabels" . | nindent 4 }}

--- a/connector/charts/oaebudt-connector/templates/service-did.yaml
+++ b/connector/charts/oaebudt-connector/templates/service-did.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: did
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 80
+      targetPort: did
+      protocol: TCP
+      name: did
+  selector:
+    {{- include "oaebudt-connector.selectorLabels" . | nindent 4 }}

--- a/connector/charts/oaebudt-connector/templates/service-dpf.yaml
+++ b/connector/charts/oaebudt-connector/templates/service-dpf.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dpf
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 80
+      targetPort: control
+      protocol: TCP
+      name: control
+  selector:
+    {{- include "oaebudt-connector.selectorLabels" . | nindent 4 }}

--- a/connector/charts/oaebudt-connector/templates/service-dsp.yaml
+++ b/connector/charts/oaebudt-connector/templates/service-dsp.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dsp
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 80
+      targetPort: protocol
+      protocol: TCP
+      name: protocol
+  selector:
+    {{- include "oaebudt-connector.selectorLabels" . | nindent 4 }}

--- a/connector/charts/oaebudt-connector/templates/service-public.yaml
+++ b/connector/charts/oaebudt-connector/templates/service-public.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: public
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 80
+      targetPort: public
+      protocol: TCP
+      name: public
+  selector:
+    {{- include "oaebudt-connector.selectorLabels" . | nindent 4 }}

--- a/connector/charts/oaebudt-connector/templates/service-sts.yaml
+++ b/connector/charts/oaebudt-connector/templates/service-sts.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sts
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: 80
+      targetPort: sts
+      protocol: TCP
+      name: sts
+  selector:
+    {{- include "oaebudt-connector.selectorLabels" . | nindent 4 }}

--- a/connector/charts/oaebudt-connector/templates/service.yaml
+++ b/connector/charts/oaebudt-connector/templates/service.yaml
@@ -1,0 +1,67 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.participant.id }}-connector
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+    {{- with .Values.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.endpoints.did.port }}
+      targetPort: did
+      protocol: TCP
+      name: did
+    - port: {{ .Values.endpoints.default.port }}
+      targetPort: default
+      protocol: TCP
+      name: default
+    - port: {{ .Values.endpoints.control.port }}
+      targetPort: control
+      protocol: TCP
+      name: control
+    - port: {{ .Values.endpoints.catalog.port }}
+      targetPort: catalog
+      protocol: TCP
+      name: catalog
+    - port: {{ .Values.endpoints.management.port }}
+      targetPort: management
+      protocol: TCP
+      name: management
+    - port: {{ .Values.endpoints.protocol.port }}
+      targetPort: protocol
+      protocol: TCP
+      name: protocol
+    - port: {{ .Values.endpoints.version.port }}
+      targetPort: version
+      protocol: TCP
+      name: version
+    - port: {{ .Values.endpoints.public.port }}
+      targetPort: public
+      protocol: TCP
+      name: public
+    - port: {{ .Values.endpoints.credentials.port }}
+      targetPort: credentials
+      protocol: TCP
+      name: credentials
+    - port: {{ .Values.endpoints.identity.port }}
+      targetPort: identity
+      protocol: TCP
+      name: identity
+    - port: {{ .Values.endpoints.presentation.port }}
+      targetPort: presentation
+      protocol: TCP
+      name: presentation
+    - port: {{ .Values.endpoints.sts.port }}
+      targetPort: sts
+      protocol: TCP
+      name: sts
+  selector:
+    {{- include "oaebudt-connector.selectorLabels" . | nindent 4 }}

--- a/connector/charts/oaebudt-connector/templates/serviceaccount.yaml
+++ b/connector/charts/oaebudt-connector/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "oaebudt-connector.serviceaccount.name" . }}
+  labels:
+    {{- include "oaebudt-connector.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.serviceAccount.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/connector/charts/oaebudt-connector/values.yaml
+++ b/connector/charts/oaebudt-connector/values.yaml
@@ -1,0 +1,242 @@
+# Default values for oaebudt-dataspace.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+global:
+  # -- Global dataspace domain (required for ingress)
+  domain: ""
+
+# This is to override the chart name.
+nameOverride: ""
+fullnameOverride: ""
+
+# OAEBUDT participant ID and DID configuration
+participant:
+  # The participant ID determines the name of the credentials to be added to the Identity Hub.
+  # Therefore, the participant ID must match the folder name in the credentials' mount path.
+  id: ""
+  # For internal Kubernetes clusters, use a DID like did:web:did-service.oaebudt.svc.cluster.local,
+  # where 'did-service' is the name of the Kubernetes service exposing the DID endpoint,
+  # and 'oaebudt' is the namespace where the service and the connector are deployed.
+  did: ""
+
+# Decentralized Claims Protocol configuration
+dcp:
+  tls:
+    enabled: false
+  # List of trusted DID issuers
+  trustedIssuers: []
+  identityHub:
+    # -- Use a base64 key
+    superuserKey: "c3VwZXItdXNlcg==.K+CKuM+8XNuEfLggseLntVljpgLnRzPMNo1WT6dWU1HUJP07l50k8AUreEIy3gcYTBn4vxzMWIg+1TDPYsxpug=="
+    # The DID-related credentials are defined in a ConfigMap and mounted into the pod,
+    # using the participant ID as a reference for both the ConfigMap name and the mount path.
+    credentials:
+      configMap: "{{ .Values.participant.id | lower }}-credentials"
+      mountPath: "/etc/dataspace/did/credentials/{{ .Values.participant.id }}/"
+
+# Federated catalog configuration
+catalog:
+  # Targets Nodes
+  nodes: []
+    # Example node:
+    #  - name: participant-b
+    #    did: "did:web:did.participant-b.svc.cluster.local"
+  crawler:
+    # -- Initial delay for the crawling to start. Leave blank for a random delay
+    initialDelay: 120
+    # -- File path to a JSON file containing TargetNode entries
+    targetsFile: "/etc/dataspace/participants.json"
+
+# Connector endpoints configuration
+endpoints:
+  # Default endpoint for incoming API calls.
+  default:
+    port: 7100
+    path: /api
+  # Provides access to the Federated Catalog for asset discovery; requires authentication.
+  catalog:
+    port: 7102
+    path: /api/catalog
+    authKey: "password"
+  # Handles internal control operations such as contract negotiations and transfer processes.
+  control:
+    port: 7103
+    path: /api/control
+  # Manages data transfer protocol negotiations between connectors.
+  protocol:
+    port: 7104
+    path: /api/dsp
+  # Offers administrative control over the connector, including policies and assets; requires authentication.
+  management:
+    port: 7105
+    path: /api/management
+    authKey: "password"
+  # Exposes information about the current version and build of the connector.
+  version:
+    port: 7106
+    path: /api/version
+  # Public endpoint for data retrieval when HTTP Pull is used; must be accessible from the internet.
+  public:
+    port: 17100
+    path: /api/public
+  # Resolves and interacts with Decentralized Identifiers (DIDs).
+  did:
+    port: 80
+    path: /
+  # Manages issuance and retrieval of Verifiable Credentials (VCs).
+  credentials:
+    port: 6102
+    path: /api/credentials
+  # Provides CRUD operations for Decentralized Identifiers (DIDs) and their documents.
+  identity:
+    port: 6103
+    path: /api/identity
+  # Enables clients to request credentials in the form of Verifiable Presentations (VPs) as defined by the DCP specification.
+  presentation:
+    port: 6104
+    path: /api/presentation
+  # Issues and validates security tokens for authenticated access within the Identity Hub.
+  sts:
+    port: 6106
+    path: /api/sts
+
+# This sets the container image
+image:
+  repository: 605134435349.dkr.ecr.us-east-1.amazonaws.com/oaebudt-dataspace/connector
+  pullPolicy: IfNotPresent
+  tag: ""
+
+# This section is for setting up autoscaling
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# This will set the replicaset count more information can be found here: https://kubernetes.io/docs/concepts/workloads/controllers/replicaset/
+replicaCount: 1
+
+# This is for setting Kubernetes Annotations to a Pod.
+podAnnotations: {}
+
+# This is for setting Kubernetes Labels to a Pod.
+podLabels: {}
+
+# This is for the secrets for pulling an image from a private repository
+imagePullSecrets: []
+
+# This section builds out the service account
+serviceAccount:
+  create: false
+  automount: true
+  annotations: {}
+  name: ""
+  # Existing image pull secret bound to the service account to use to obtain the container image from private registries
+  imagePullSecrets: []
+
+podSecurityContext: {}
+# fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+# runAsUser: 1000
+
+livenessProbe:
+  # Whether to enable kubernetes [liveness-probe]
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  # Whether to enable kubernetes [readiness-probes]
+  enabled: true
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+
+# Resource management for the container
+resources:
+  limits:
+    cpu: 1.5
+    memory: 1536Mi
+  requests:
+    cpu: 500m
+    memory: 1024Mi
+
+# Node selector
+nodeSelector: {}
+# Tolerations
+tolerations: []
+# Affinity to configure which nodes the pods can be scheduled on
+affinity: {}
+
+service:
+  # Service type to expose the running application on a set of Pods as a network service.
+  type: ClusterIP
+  labels: {}
+  annotations: {}
+
+# This block is for setting up the ingress for more information can be found here: https://kubernetes.io/docs/concepts/services-networking/ingress/
+ingress:
+  enabled: enable
+  className: ""
+  annotations: []
+  #  kubernetes.io/ingress.class: nginx
+  #  kubernetes.io/tls-acme: "true"
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+# PostgreSQL chart configuration
+postgresql:
+  ## ref: https://github.com/bitnami/charts/blob/main/bitnami/postgresql/values.yaml
+  # -- Switch to enable or disable the PostgreSQL helm chart
+  install: true
+  schema:
+    # -- Enable auto-creation of the schema on boot
+    autoCreate: true
+  auth:
+    # -- Database name must begin with a letter (a-z) or underscore (_)
+    # -- Subsequent characters can be letters, digits (0-9), or underscores
+    # -- Maximum name length is 31 characters by default
+    database: "oaebudt_connector"
+    # -- Username must begin with a letter (a-z) or underscore (_)
+    # -- Subsequent characters can be letters, digits (0-9), or underscores
+    # -- Maximum name length is 31 characters by default
+    username: "oaebudt_connector"
+    password: "oaebudt_connector"
+
+# HashiCorp Vault chart configuration
+vault:
+  ## ref: https://github.com/hashicorp/vault-helm/blob/main/values.yaml
+  # -- Switch to enable or disable the HashiCorp Vault helm chart
+  install: true
+  injector:
+    enabled: false
+  server:
+    dev:
+      enabled: true
+      devRootToken: "root"
+    postStart:    # must be set externally!
+  hashicorp:
+    url: "http://{{ .Release.Name }}-vault:8200"
+    token: "root"
+    timeout: 30
+    healthCheck:
+      enabled: true
+      standbyOk: true
+    paths:
+      secret: /v1/secret
+      health: /v1/sys/health
+      folder: ""

--- a/connector/charts/oaebudt-connector/values.yaml
+++ b/connector/charts/oaebudt-connector/values.yaml
@@ -225,14 +225,13 @@ vault:
   injector:
     enabled: false
   server:
-    dev:
+    standalone:
       enabled: true
-      devRootToken: "root"
-    postStart:    # must be set externally!
   hashicorp:
     url: "http://{{ .Release.Name }}-vault:8200"
-    token: "root"
     timeout: 30
+    tokenSecret: "{{ .Release.Name }}-vault-token"
+    tokenSecretKey: "root-token"
     healthCheck:
       enabled: true
       standbyOk: true

--- a/connector/charts/oaebudt-issuer/values.yaml
+++ b/connector/charts/oaebudt-issuer/values.yaml
@@ -1,0 +1,76 @@
+# values.yaml - Configuration for deploying the NGINX server that hosts the DID document
+# for the OAEBUDT Dataspace DID Issuer. This is required for the DCP workflow to function properly,
+# enabling validation and signed credential issuance for participants within the Dataspace.
+
+# The release name must be overridden to 'issuer' to ensure the service is named 'issuer',
+# resulting in the fully qualified Kubernetes DNS name: issuer.oaebudt.svc.cluster.local —
+# which must match the service endpoint defined in the DID document.
+nameOverride: "issuer"
+fullnameOverride: "issuer"
+
+# Set the service type for Kubernetes
+service:
+  type: ClusterIP
+
+# Mount an extra volume from a ConfigMap named 'did-document'
+extraVolumes:
+  - name: did-document
+    configMap:
+      name: did-document
+      items:
+        - key: did.json
+          path: did.json
+
+# Mount the volume to the NGINX server at the well-known path
+extraVolumeMounts:
+  - name: did-document
+    mountPath: /opt/bitnami/nginx/html/.well-known/
+    readOnly: true
+
+# Create the ConfigMap that holds the DID document
+extraDeploy:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: did-document
+    data:
+      did.json: |
+        {
+          "service":[],
+          "verificationMethod":[
+            {
+              "id":"did:web:issuer.oaebudt.svc.cluster.local#key-1",
+              "type":"JsonWebKey2020",
+              "controller":"did:web:issuer.oaebudt.svc.cluster.local",
+              "publicKeyMultibase":null,
+              "publicKeyJwk":{
+                "kty":"OKP",
+                "crv":"Ed25519",
+                "x":"VU0WtUeeXU2hPcRAOr1jrOD9TOnX9sh3UN4INhVzl1M"
+              }
+            }
+          ],
+          "authentication":[
+            "key-1"
+          ],
+          "id":"did:web:issuer.oaebudt.svc.cluster.local",
+          "@context":[
+            "https://www.w3.org/ns/did/v1",
+            {
+              "@base":"did:web:issuer.oaebudt.svc.cluster.local"
+            }
+          ]
+        }
+
+# Define the NGINX server block to serve the DID document
+serverBlock: |
+  server {
+    listen 0.0.0.0:8080;
+    root /opt/bitnami/nginx/html;
+  
+    location = /.well-known/did.json {
+      default_type application/json;
+      add_header Access-Control-Allow-Origin *;
+      add_header Cache-Control "public, max-age=3600";
+    }
+  }


### PR DESCRIPTION
## Description

This PR introduces:

1. A new Helm chart for the connector under charts/oaebudt-connector (initial version). This is an umbrella chart that includes PostgreSQL and Vault (standalone mode)as dependencies.
2. Helm release configuration (values.yaml) for exposing the DID Document Issuer using the NGINX Helm chart under charts/oaebudt-issuer.

Key Components
Connector Chart Includes:

1. Deployment: Template for the connector

2. Services:
- Global service (service.yaml) exposing all endpoints
- Individual services for Credentials, DID, DSP, DPF, STS, and Public endpoints
These services are defined to enable clean references within DID Documents and Verifiable Credentials without exposing ports.
Instead of port-based URLs, DNS-based hostnames are used (e.g., did.participant-x..., dsp.participant-a..., etc.).

3. Secret containing:
- x-api-key for API authentication endpoints
- Super-user credentials for IdentityHub access
- A Secret contains Vault token

4. Ingress:
For development use only, this Ingress exposes some of the connector’s endpoints externally to support integration testing. In a production environment, components such as API management should not be publicly accessible. This configuration is intended exclusively for development, particularly because the backend component is not yet set up.

5. ConfigMaps:
- Participant DID Document
- Static credentials
- A list of dataspace participants for use in federated catalog crawling

6. Job: 
- A Kubernetes Job is included to seed participant into the IdentityHub. It is intentionally not defined as a Helm hook to prevent the Helm release from failing if the Job does.
Seeding participant is an optional initialization step, not required for the connector to function. Participant data can also be added manually after the release is installed.
- A Vault init job initializes and unseals Vault, then creates a Secret containing the token. This Secret is referenced in the deployment template and is used by the connector.

##  Notes
- Static credentials are included for the six participants in the OAEBUDT dataspace under charts/oaebudt-connector/credentials.
- The Helm release namespace determines the correct set of credentials to use.
- The IdentityHub is considered to be built as an embedded component directly within the connector.
