### PR TITLE
build: create an allinone connector for EKS deployment

### DIFF
--- a/connector/gradle/libs.versions.toml
+++ b/connector/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ postgres = { module = "org.postgresql:postgresql", version.ref = "postgres" }
 edc-fc-core = { module = "org.eclipse.edc:federated-catalog-core", version.ref = "edc" }
 edc-fc-ext-api = { module = "org.eclipse.edc:federated-catalog-api", version.ref = "edc" }
 edc-fc-spi-crawler = { module = "org.eclipse.edc:crawler-spi", version.ref = "edc" }
-
+edc-fc-api = { module = "org.eclipse.edc:federated-catalog-core", version.ref = "edc" }
 
 # BOM modules
 edc-bom-controlplane = { module = "org.eclipse.edc:controlplane-dcp-bom", version.ref = "edc" }

--- a/connector/launchers/oaebudt-connector/Dockerfile
+++ b/connector/launchers/oaebudt-connector/Dockerfile
@@ -1,0 +1,51 @@
+# Stage 1: Build the JAR using Gradle
+FROM eclipse-temurin:23.0.2_7-jdk-alpine AS builder
+
+WORKDIR /app
+
+# Copy the Gradle configuration files
+COPY ./gradlew  ./build.gradle.kts ./gradle.properties ./settings.gradle.kts ./
+COPY ./gradle ./gradle
+
+# Make gradlew executable and download dependencies as a separate step to leverage Docker cache
+RUN chmod +x ./gradlew && ./gradlew dependencies --no-daemon
+
+# Copy connector sources
+COPY ./launchers/controlplane ./launchers/controlplane
+COPY ./launchers/dataplane ./launchers/dataplane
+COPY ./launchers/identity-hub ./launchers/identity-hub
+COPY ./launchers/oaebudt-connector ./launchers/oaebudt-connector
+
+# Copy connector extensions
+COPY ./extensions/catalog-node-resolver ./extensions/catalog-node-resolver
+COPY ./extensions/credential-from-file ./extensions/credential-from-file
+COPY ./extensions/dcp-impl ./extensions/dcp-impl
+COPY ./extensions/superuser-seed ./extensions/superuser-seed
+
+
+# Run Gradle to build the JAR with parallel execution for faster builds
+RUN ./gradlew clean :launchers:runtime-allinone:build --parallel --no-daemon
+
+# Stage 2: Create the runtime image
+FROM eclipse-temurin:23.0.2_7-jre-alpine
+
+WORKDIR /app
+
+# Create a non-root user to run the application
+RUN addgroup -S oaebudt && adduser -S oaebudt -G oaebudt
+USER oaebudt
+
+# Copy the JAR from the builder stage
+COPY --from=builder /app/launchers/runtime-allinone/build/libs/*.jar connector.jar
+
+# Set environment variables
+ENV WEB_HTTP_PORT="8080" \
+    WEB_HTTP_PATH="/api" \
+    JVM_ARGS=""
+
+EXPOSE ${WEB_HTTP_PORT}
+
+HEALTHCHECK --interval=5s --timeout=5s --retries=10 CMD wget --spider --quiet --timeout=5 --tries=1 http://localhost:${WEB_HTTP_PORT}${WEB_HTTP_PATH}/check/health || exit 1
+
+# Use "exec" for graceful termination (SIGINT) to reach JVM.
+ENTRYPOINT [ "sh", "-c", "exec java ${JVM_ARGS} -jar connector.jar --log-level=debug"]

--- a/connector/launchers/oaebudt-connector/build.gradle.kts
+++ b/connector/launchers/oaebudt-connector/build.gradle.kts
@@ -19,7 +19,6 @@ dependencies {
 }
 
 tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
-    exclude("**/pom.properties", "**/pom.xml")
     mergeServiceFiles()
     archiveFileName.set("${project.name}.jar")
 }

--- a/connector/launchers/oaebudt-connector/build.gradle.kts
+++ b/connector/launchers/oaebudt-connector/build.gradle.kts
@@ -15,6 +15,9 @@ dependencies {
     }
     runtimeOnly(project(":launchers:identity-hub"))
 
+    runtimeOnly(libs.edc.fc.core)
+    runtimeOnly(libs.edc.fc.api)
+
     runtimeOnly(libs.edc.vault.hashicorp)
 }
 

--- a/connector/launchers/oaebudt-connector/build.gradle.kts
+++ b/connector/launchers/oaebudt-connector/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    `java-library`
+    alias(libs.plugins.shadow)
+}
+
+dependencies {
+    runtimeOnly(project(":extensions:catalog-node-resolver"))
+    runtimeOnly(project(":extensions:dcp-impl"))
+
+    runtimeOnly(project(":launchers:controlplane")) {
+        exclude(group = "org.eclipse.edc", "data-plane-selector-client")
+    }
+    runtimeOnly(project(":launchers:dataplane")) {
+        exclude(group = "org.eclipse.edc", "data-plane-selector-client")
+    }
+    runtimeOnly(project(":launchers:identity-hub"))
+
+    runtimeOnly(libs.edc.vault.hashicorp)
+}
+
+tasks.withType<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar> {
+    exclude("**/pom.properties", "**/pom.xml")
+    mergeServiceFiles()
+    archiveFileName.set("${project.name}.jar")
+}
+
+application {
+    mainClass.set("org.eclipse.edc.boot.system.runtime.BaseRuntime")
+}

--- a/connector/settings.gradle.kts
+++ b/connector/settings.gradle.kts
@@ -29,5 +29,6 @@ include(":launchers:controlplane")
 include(":launchers:dataplane")
 include(":launchers:runtime-embedded")
 include(":launchers:identity-hub")
+include(":launchers:oaebudt-connector")
 
 include("tests")


### PR DESCRIPTION
## Description

Create an all-in-one connector for EKS deployment that includes IdentityHub. 
The Keycloak extension has been removed from the current build because it is intended to secure the backend—not the connector. Since the backend has not been set up yet, the extension was excluded to proceed with deployment. Once the backend is ready, the extension will be added to ensure backend security.

