### PR TITLE
120 allow multiple uploads of same report by adding uuid's to asset ids

### DIFF
--- a/connector/extensions/web-service/src/main/java/org/oaebudt/edc/web/ReportApiController.java
+++ b/connector/extensions/web-service/src/main/java/org/oaebudt/edc/web/ReportApiController.java
@@ -8,7 +8,6 @@ import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
-import org.eclipse.edc.spi.monitor.Monitor;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.oaebudt.edc.web.dto.CreateAssetRequest;
 import org.oaebudt.edc.web.model.ReportType;
@@ -25,10 +24,8 @@ import static jakarta.ws.rs.core.MediaType.WILDCARD;
 public class ReportApiController {
 
     private final ReportService reportService;
-    private final Monitor monitor;
 
-    public ReportApiController(Monitor monitor, ReportService reportService) {
-        this.monitor = monitor;
+    public ReportApiController(ReportService reportService) {
         this.reportService = reportService;
     }
 
@@ -38,8 +35,8 @@ public class ReportApiController {
     public Response createAsset(CreateAssetRequest request) {
 
         return reportService.createAsset(request)
-                .map(unused -> Response.status(Response.Status.CREATED)
-                        .entity(Json.createObjectBuilder().add("message", "Asset created successfully").build().toString())
+                .map(assetId -> Response.status(Response.Status.CREATED)
+                        .entity(Json.createObjectBuilder().add("message", "Asset created successfully").add("assetId", assetId).build().toString())
                         .build()).orElse(serviceFailure -> badRequest("Something went wrong", serviceFailure.getFailureDetail()));
     }
 
@@ -55,8 +52,8 @@ public class ReportApiController {
                                @FormDataParam("reportType") ReportType reportType) {
 
         return reportService.uploadAndCreateAsset(uploadedInputStream, title, accessDefinition, metadataJson, reportType)
-                .map(unused -> Response.status(Response.Status.CREATED)
-                        .entity(Json.createObjectBuilder().add("message", "Asset created successfully").build().toString())
+                .map(assetId -> Response.status(Response.Status.CREATED)
+                        .entity(Json.createObjectBuilder().add("message", "Asset created successfully").add("assetId", assetId).build().toString())
                         .build()).orElse(serviceFailure -> badRequest("Something went wrong", serviceFailure.getFailureDetail()));
     }
 

--- a/connector/extensions/web-service/src/main/java/org/oaebudt/edc/web/WebApiExtension.java
+++ b/connector/extensions/web-service/src/main/java/org/oaebudt/edc/web/WebApiExtension.java
@@ -83,8 +83,7 @@ public class WebApiExtension implements ServiceExtension {
         portMappingRegistry.register(new PortMapping(WEB, reportApiConfiguration.port(), reportApiConfiguration.path()));
         portMappingRegistry.register(new PortMapping(CONSUMER, consumerApiConfiguration.port(), consumerApiConfiguration.path()));
 
-        webService.registerResource(WEB, new ReportApiController(
-                context.getMonitor(), reportService));
+        webService.registerResource(WEB, new ReportApiController(reportService));
         webService.registerResource(WEB, new ParticipantGroupApiController(participantGroupService, monitor));
         webService.registerResource(CONSUMER, new ConsumerApiController(reportStore));
     }

--- a/connector/extensions/web-service/src/main/java/org/oaebudt/edc/web/service/ReportService.java
+++ b/connector/extensions/web-service/src/main/java/org/oaebudt/edc/web/service/ReportService.java
@@ -58,7 +58,7 @@ public class ReportService {
             return ServiceResult.badRequest(validationResult.getErrors());
         }
 
-        String assetId = "%s-%s".formatted(request.reportType(), UUID.randomUUID());
+        String assetId = getUniqueAssetId(request.reportType());
         createAssetInConnector(
                 assetId,
                 request.title(),
@@ -72,6 +72,10 @@ public class ReportService {
                 request.headers()
         );
         return ServiceResult.success(assetId);
+    }
+
+    private String getUniqueAssetId(ReportType reportType) {
+        return "%s-%s".formatted(reportType, UUID.randomUUID());
     }
 
     public ServiceResult<String> uploadAndCreateAsset(InputStream file, String title, String accessDefinition, String metadataJson, ReportType reportType) {
@@ -96,7 +100,7 @@ public class ReportService {
             reportStore.saveReport(enriched.toString(), reportType);
 
             String uri = consumerApiBaseUrl.resolve("report?reportType=" + reportType.name()).toString();
-            String assetId = "%s-%s".formatted(reportType, UUID.randomUUID());
+            String assetId = getUniqueAssetId(reportType);
             createAssetInConnector(assetId, title, metadata, reportType, accessDefinition, uri, "GET", null, null, Collections.emptyMap());
 
             return ServiceResult.success(assetId);

--- a/connector/extensions/web-service/src/test/java/org/oaebudt/edc/web/service/ReportServiceTest.java
+++ b/connector/extensions/web-service/src/test/java/org/oaebudt/edc/web/service/ReportServiceTest.java
@@ -3,6 +3,7 @@ package org.oaebudt.edc.web.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.assertj.core.api.Assertions;
 import org.eclipse.edc.connector.controlplane.asset.spi.domain.Asset;
 import org.eclipse.edc.connector.controlplane.contract.spi.types.offer.ContractDefinition;
 import org.eclipse.edc.connector.controlplane.services.spi.asset.AssetService;
@@ -21,7 +22,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.function.Consumer;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -98,8 +98,8 @@ public class ReportServiceTest {
         verify(reportStore).saveReport(anyString(), eq(reportType));
         verify(assetService).create(any(Asset.class));
         verify(contractDefinitionService).create(any(ContractDefinition.class));
-        Pattern pattern = Pattern.compile("^ITEM_REPORT.*");
-        assertTrue(pattern.matcher(result.getContent()).matches());
+        Assertions.assertThat(result.succeeded()).isTrue();
+        Assertions.assertThat(result.getContent()).startsWith("ITEM_REPORT");
     }
 
     @Test

--- a/connector/extensions/web-service/src/test/java/org/oaebudt/edc/web/service/ReportServiceTest.java
+++ b/connector/extensions/web-service/src/test/java/org/oaebudt/edc/web/service/ReportServiceTest.java
@@ -21,6 +21,7 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.function.Consumer;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -92,11 +93,13 @@ public class ReportServiceTest {
         when(contractDefinitionService.findById(anyString())).thenReturn(null);
         when(contractDefinitionService.create(any(ContractDefinition.class))).thenReturn(ServiceResult.success());
 
-        reportService.uploadAndCreateAsset(inputStream, title, accessDefinition, metadata, reportType);
+        ServiceResult<String> result = reportService.uploadAndCreateAsset(inputStream, title, accessDefinition, metadata, reportType);
 
         verify(reportStore).saveReport(anyString(), eq(reportType));
         verify(assetService).create(any(Asset.class));
         verify(contractDefinitionService).create(any(ContractDefinition.class));
+        Pattern pattern = Pattern.compile("^ITEM_REPORT.*");
+        assertTrue(pattern.matcher(result.getContent()).matches());
     }
 
     @Test

--- a/connector/extensions/web-service/src/test/java/org/oaebudt/edc/web/service/ReportServiceTest.java
+++ b/connector/extensions/web-service/src/test/java/org/oaebudt/edc/web/service/ReportServiceTest.java
@@ -106,7 +106,7 @@ public class ReportServiceTest {
         String accessDefinition = "public";
         ReportType reportType = ReportType.ITEM_REPORT;
 
-        ServiceResult<Void> result = reportService.uploadAndCreateAsset(inputStream, title, accessDefinition, metadata, reportType);
+        ServiceResult<String> result = reportService.uploadAndCreateAsset(inputStream, title, accessDefinition, metadata, reportType);
         assertTrue(result.failed());
         assertTrue(result.getFailureDetail().contains("Invalid report json:"));
     }
@@ -117,7 +117,7 @@ public class ReportServiceTest {
         String title = "Test Report";
         ReportType reportType = ReportType.ITEM_REPORT;
 
-        ServiceResult<Void> result = reportService.uploadAndCreateAsset(inputStream, title, null, metadata, reportType);
+        ServiceResult<String> result = reportService.uploadAndCreateAsset(inputStream, title, null, metadata, reportType);
 
         assertTrue(result.failed());
         assertEquals("Invalid access definition", result.getFailureDetail());
@@ -132,7 +132,7 @@ public class ReportServiceTest {
         String accessDefinition = "public";
         ReportType reportType = ReportType.ITEM_REPORT;
 
-        ServiceResult<Void> result = reportService.uploadAndCreateAsset(inputStream, title, accessDefinition, jsonMetadata, reportType);
+        ServiceResult<String> result = reportService.uploadAndCreateAsset(inputStream, title, accessDefinition, jsonMetadata, reportType);
 
         assertTrue(result.failed());
         assertTrue(result.getFailureDetail().contains(expectedErrorMessage));

--- a/connector/tests/src/test/java/org/oaebudt/edc/ManagementApiTransferTest.java
+++ b/connector/tests/src/test/java/org/oaebudt/edc/ManagementApiTransferTest.java
@@ -31,7 +31,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -46,7 +45,6 @@ import org.eclipse.edc.junit.extensions.RuntimeExtension;
 import org.eclipse.edc.junit.extensions.RuntimePerClassExtension;
 import org.eclipse.edc.spi.system.ServiceExtension;
 import org.jboss.resteasy.util.HttpHeaderNames;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -478,25 +476,24 @@ class ManagementApiTransferTest {
 
         String jsonContent = objectMapper.writeValueAsString(jsonContentMap);
 
-        sendMultipartRequest(accessToken, jsonContent, metadata, reportUri);
-        sendMultipartRequest(accessToken, jsonContent, metadata, reportUri);
+        uploadReportMultipart(accessToken, jsonContent, metadata, reportUri);
+        uploadReportMultipart(accessToken, jsonContent, metadata, reportUri);
 
 
-        JsonArray jsonArray = CONSUMER.getCatalogDatasets(PROVIDER);
+        JsonArray datasets = CONSUMER.getCatalogDatasets(PROVIDER);
 
         Pattern pattern = Pattern.compile("^TITLE_REPORT.*");
 
-        long count = jsonArray.stream()
+        long count = datasets.stream()
                 .map(JsonObject.class::cast)
                 .map(obj -> obj.getString("@id", ""))
                 .filter(id -> pattern.matcher(id).matches())
                 .count();
 
-        Assertions.assertThat(count > 1).isTrue();
-
+        Assertions.assertThat(count).isGreaterThan(1);
     }
 
-    private static void sendMultipartRequest(String accessToken, String jsonContent, String metadata, String reportUri) {
+    private static void uploadReportMultipart(String accessToken, String jsonContent, String metadata, String reportUri) {
         RestAssured
                 .given()
                 .header(HttpHeaderNames.AUTHORIZATION, "Bearer " + accessToken)


### PR DESCRIPTION
## Description

We have 2 types of report ITEM_REPORT and TITLE_REPORT
Initially, each report types are only allowed to have one asset each. 
Implementation has now been changed to allow multiple report uploads ffor same report type.
This is done by having unique asset Id's for each report uploads

### How to test it

Upload report with same report type twice.
Check federated catalog and notice both entries

### Linked Issue
closes #120 

## Approach
Asset Id's is now a combination of report type and random uuid
This allows for unique uploads
