### PR TITLE
feat: expose admin console keycloak

### DIFF
--- a/connector/charts/oaebudt-connector/templates/config-map-keycloak-realm.yaml
+++ b/connector/charts/oaebudt-connector/templates/config-map-keycloak-realm.yaml
@@ -13,39 +13,6 @@ data:
       "accessTokenLifespan": {{ .Values.keycloak.participantRealm.accessTokenLifespan | default 1500 }},
       "roles": {
         "realm": [
-          {
-            "name": "admin",
-            "description": "${admin}",
-            "composite": true,
-            "composites": {
-              "client": {
-                "realm-management": [
-                  "manage-users",
-                  "manage-authorization",
-                  "realm-admin",
-                  "query-groups",
-                  "manage-realm",
-                  "view-realm",
-                  "query-users",
-                  "manage-events",
-                  "view-users",
-                  "create-client",
-                  "manage-clients",
-                  "manage-identity-providers",
-                  "view-events",
-                  "query-clients",
-                  "view-authorization",
-                  "query-realms",
-                  "impersonation",
-                  "view-identity-providers",
-                  "view-clients"
-                ]
-              }
-            },
-            "clientRole": false,
-            "attributes": {}
-          }{{- if gt (len .Values.keycloak.participantRealm.userRealmRoles) 0 }},{{- end }}
-
           {{- $roleLength := len .Values.keycloak.participantRealm.userRealmRoles -}}
           {{- range $index, $role := .Values.keycloak.participantRealm.userRealmRoles }}
           {

--- a/connector/charts/oaebudt-connector/templates/config-map-keycloak-realm.yaml
+++ b/connector/charts/oaebudt-connector/templates/config-map-keycloak-realm.yaml
@@ -13,6 +13,39 @@ data:
       "accessTokenLifespan": {{ .Values.keycloak.participantRealm.accessTokenLifespan | default 1500 }},
       "roles": {
         "realm": [
+          {
+            "name": "admin",
+            "description": "${admin}",
+            "composite": true,
+            "composites": {
+              "client": {
+                "realm-management": [
+                  "manage-users",
+                  "manage-authorization",
+                  "realm-admin",
+                  "query-groups",
+                  "manage-realm",
+                  "view-realm",
+                  "query-users",
+                  "manage-events",
+                  "view-users",
+                  "create-client",
+                  "manage-clients",
+                  "manage-identity-providers",
+                  "view-events",
+                  "query-clients",
+                  "view-authorization",
+                  "query-realms",
+                  "impersonation",
+                  "view-identity-providers",
+                  "view-clients"
+                ]
+              }
+            },
+            "clientRole": false,
+            "attributes": {}
+          }{{- if gt (len .Values.keycloak.participantRealm.userRealmRoles) 0 }},{{- end }}
+
           {{- $roleLength := len .Values.keycloak.participantRealm.userRealmRoles -}}
           {{- range $index, $role := .Values.keycloak.participantRealm.userRealmRoles }}
           {

--- a/connector/charts/oaebudt-connector/templates/ingress.yaml
+++ b/connector/charts/oaebudt-connector/templates/ingress.yaml
@@ -123,6 +123,13 @@ spec:
                 name: {{ .Release.Name }}-keycloak
                 port:
                   name: http
+          - path: /admin
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-keycloak
+                port:
+                  name: http
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}


### PR DESCRIPTION
## Description

Add an ingress endpoint to expose the Admin Keycloak console, allowing the coordination office to manage identity provisioning.