### PR TITLE
feat: Add Python API client proof-of-concept

### DIFF
--- a/examples/python-client/README.md
+++ b/examples/python-client/README.md
@@ -1,0 +1,72 @@
+# Python API Client (Proof of Concept)
+
+This directory contains a limited-functionality Python client for interacting 
+with the OAEBUDT Dataspace API. Its primary purpose is to provide a working 
+example of how to handle the token authentication logic.
+
+Currently, it can be used to create and fetch participant groups, as well as 
+create a file-based report. 
+
+---
+
+## ⚠️ Important Disclaimer
+
+* **Proof of Concept:** This client is a proof of concept and has **not** been 
+thoroughly tested. Use it as a reference, not as production-ready code.
+* **No Pip Package:** While the directory structure is set up to mimic a 
+standard Python package, it is **not** currently distributed or installable 
+via `pip`.
+* **Limited Scope:** The client currently only implements basic authentication 
+and example methods. It can be expanded in the future to interact with more 
+API endpoints.
+
+---
+
+## File Structure
+
+* `/oaebudt_dataspace/`: This directory acts as the Python package, 
+containing the client's source code.
+* `/demo.py`: This file contains example usage patterns for the client.
+
+---
+
+## How to Use
+
+The `demo.py` file is for reference only and should not be run directly. To 
+test the client, you should use its code snippets in a Python shell or adapt 
+them for your own scripts.
+
+### Example: Using the Client Interactively
+
+1.  Navigate to the root of this directory in your terminal.
+2.  Start a Python interpreter (`python`, `python3` or `ipython`).
+3.  Import and instantiate the client as shown below.
+
+```python
+# Import the client class from the local package
+from oaebudt_dataspace import DataspaceClient
+
+
+# Replace with your actual configuration values
+client = DataspaceClient(
+    domain_name="your_domain_name",
+    realm_name="your_realm_name",
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+    username="your_username",
+    password="your_password",
+)
+```
+
+The client can now be used to interact with the API. It can perform get- and 
+post-requests, which will automatically handle authentication in the 
+background. 
+
+Additional methods include
+
+ * **client.create_participant_group()**
+ * **client.get_participant_group()**
+ * **client.create_report()**
+ 
+
+See the `demo.py` file for examples.

--- a/examples/python-client/demo.py
+++ b/examples/python-client/demo.py
@@ -1,0 +1,127 @@
+# /// script
+# requires-python = ">=3.8"
+# dependencies = [
+#     "requests",
+# ]
+# ///
+
+if __name__ == '__main__':
+    import sys
+    print('\nPlease do not run this script directly.\n')
+    sys.exit(1)
+
+
+from os import getenv
+
+from oaebudt_dataspace import DataspaceClient
+
+
+# These constants can be set in the environment or hard-coded if preferred.
+DOMAIN_NAME = getenv('DOMAIN_NAME', '<domain-name>')
+REALM_NAME = getenv('REALM_NAME', '<realm-name>')
+CLIENT_ID = getenv('CLIENT_ID', '<client-id>')
+CLIENT_SECRET = getenv('CLIENT_SECRET', '<client-secret>')
+USERNAME = getenv('USERNAME', '<username>')
+PASSWORD = getenv('PASSWORD', '<password>')
+
+
+# 1. Authentication and Token Retrieval
+
+# Initialise the client
+client = DataspaceClient(
+    domain_name=DOMAIN_NAME,
+    realm_name=REALM_NAME,
+    client_id=CLIENT_ID,
+    client_secret=CLIENT_SECRET,
+    username=USERNAME,
+    password=PASSWORD,
+)
+# The client automatically fetches the token, used for interacting
+# with the API, and sets it in the request headers.
+
+
+# 2. Report Publishing
+# 2.1. Participant Groups Management
+
+# 2.1.1. Create Participant Group
+# Please change the group_name and participants as required.
+response = client.create_participant_group(
+    group_name='<group-name>',
+    participants=[
+        "did:web:participant1-domain-name",
+        "did:web:participant2-domain-name",
+        "did:web:participant3-domain-name"
+    ],
+)
+
+print(response.json())
+# If the response was successful, you should be able to see the following
+# -> {'message': 'Participants added to group'}
+
+
+# 2.1.2. Retrieve Participant Group
+participant_groups = client.retrieve_participant_groups()
+print(participant_groups)
+"""# -> 
+[
+  {
+    "id": "<group-name>",
+    "participants": [
+      "did:web:participant3-domain-name",
+      "did:web:participant2-domain-name",
+      "did:web:participant1-domain-name"
+    ]
+  }
+]
+"""
+
+# 2.2. Asset Creation
+# Again, please change the variables, as needed.
+
+# The usage report file (must be in JSON format)
+file_to_upload = '/path/to/your/local/file/report.json'
+
+# Descriptive title for the report
+title = "ITEM Report Publisher XYZ 1st semester"
+
+# Additional report information
+metadata = {
+    'legalOrganizationName': 'University XYZ',
+    'countryOfOrganization': 'United States',
+    'organizationWebsite': 'https://www.example-press.org',
+    'contactPerson': 'Jane Smith',
+    'contactEmail': 'jane.smith@example-press.org',
+    'dataProcessingDescription': 'Raw usage logs are processed using COUNTER Release 5 processing rules...',
+    'qualityAssuranceMeasures': 'Monthly data validation process including outlier detection, completeness checking...',
+    'dataLicensingTerms': 'Data is provided under CC-BY license...',
+    'dataAccuracyLevel': 3,
+    'dataGenerationTransparencyLevel': 2,
+    'dataDeliveryReliabilityLevel': 3,
+    'dataFrequencyLevel': 2,
+    'dataGranularityLevel': 2,
+    'dataConsistencyLevel': 2
+}
+
+# Optional: Report category: "ITEM_REPORT" or "TITLE_REPORT"
+report_category = "ITEM_REPORT"
+
+# Name of the Participant Group allowed to access the report.
+access_group = "<group-name>"
+
+
+# API Request to Upload Report File
+response = client.create_file_based_report(
+    file_path=file_to_upload,
+    asset_metadata=metadata,
+    report_title=title,
+    target_audience=access_group,
+    report_type=report_category,
+)
+
+print(response.json())
+""" # ->
+{
+    'message': 'Asset created successfully',
+    'assetId': 'ITEM_REPORT-e129824x-qc21-137z-94bq-12bd52f8a62p'
+}
+"""

--- a/examples/python-client/oaebudt_dataspace/__init__.py
+++ b/examples/python-client/oaebudt_dataspace/__init__.py
@@ -1,0 +1,1 @@
+from .client import DataspaceClient

--- a/examples/python-client/oaebudt_dataspace/client.py
+++ b/examples/python-client/oaebudt_dataspace/client.py
@@ -1,0 +1,166 @@
+from functools import wraps
+import json
+from logging import getLogger
+from dataclasses import dataclass, field
+
+import requests
+
+
+logger = getLogger(__name__)
+
+
+@dataclass
+class DataspaceClient:
+    """Client base class which handles authentication via the Tokens API.
+
+    This is mostly just a wrapper around the requests library, which updates
+    request headers with a JWT from the Tokens API for authentication.
+    """
+    domain_name:  str = field(repr=False, default='')
+    realm_name:  str = field(repr=False, default='')
+    client_id:  str = field(repr=False, default='')
+    client_secret:  str = field(repr=False, default='')
+    username:  str = field(repr=False, default='')
+    password:  str = field(repr=False, default='')
+
+    token: str = ''
+
+    def __post_init__(self):
+        """Set tokens Authorization header and add it to client requests."""
+        self.header = {}
+
+        self.get = self.authenticated_request(requests.get)
+        self.post = self.authenticated_request(requests.post)
+        # Can be extended to other methods if needed.
+
+        self.set_token()
+        self.set_auth_header()
+
+    def get_token(self):
+        """Fetch token from token API endpoint."""
+        endpoint = (
+            f'https://{self.domain_name}/realms/'
+            f'{self.realm_name}/protocol/openid-connect/token'
+        )
+        data = dict(
+            grant_type='password',
+            client_id=self.client_id,
+            client_secret=self.client_secret,
+            username=self.username,
+            password=self.password,
+        )
+        response = requests.post(endpoint, data=data)
+
+        if response.status_code != 200:
+            raise ValueError(response.content.decode('utf-8'))
+
+        return response.json()['access_token']
+
+    def set_token(self):
+        """Fetch token to be used for requests."""
+
+        token_requirements = (  # Make sure all required fields are set.
+            self.domain_name,
+            self.realm_name,
+            self.client_id,
+            self.client_secret,
+            self.username,
+            self.password,
+        )
+
+        if not all(token_requirements):
+            raise TypeError(
+                "Please set all credentials required to fetch a token."
+            )
+
+        self.token = self.get_token()
+
+    def set_auth_header(self, token_has_expired=False):
+        """Sets Authorization header for the client using the Bearer schema.
+
+        Args:
+            token_has_expired (bool): True if token has expired.
+        """
+        if not self.token or token_has_expired:
+            self.set_token()
+
+        self.header.update(Authorization=f'Bearer {self.token}')
+
+    def authenticated_request(self, func):
+        """Decorator to add token authentication to requests."""
+
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            kwargs.setdefault('headers', {}).update(self.header)
+            response = func(*args, **kwargs)
+
+            if response.status_code in (401, 403):  # Assume token has expired
+                self.set_auth_header(token_has_expired=True)
+                kwargs['headers'].update(self.header)
+                response = func(*args, **kwargs)
+
+            return response
+        return wrapper
+
+    def __str__(self):
+        return self.__class__.__name__
+
+    # Functionality
+    def create_participant_group(
+            self,
+            group_name,
+            participants,  # list
+    ):
+        endpoint = (
+            f'https://{self.domain_name}/api/web/participant/group'
+        )
+        data = {
+            "groupName": group_name,
+            "participants": participants,
+        }
+        return self.post(endpoint, json=data)
+
+    def retrieve_participant_groups(self):
+        response = self.get(
+            f'https://{self.domain_name}/api/web/participant/group',
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def create_file_based_report(
+            self,
+            file_path,
+            asset_metadata,
+            report_title,
+            target_audience,    # noqa str: group_name from self.create_participant_group
+            report_type='ITEM_REPORT',
+    ):
+        endpoint = f'https://{self.domain_name}/api/web/report/upload'
+        form_data = {  # Form fields dict - Metadata is converted to JSON.
+            'title': report_title,
+            'reportType': report_type,
+            'accessDefinition': f'allow-{target_audience}',
+            'metadata': json.dumps(asset_metadata)
+        }
+        try:
+            with open(file_path, 'rb') as f:
+                files_payload = {'file': f}
+
+                logger.info("Sending request to:", endpoint)
+                logger.info("Form data:", form_data)
+                logger.info("File:", file_path)
+
+                response = self.post(
+                    endpoint,
+                    data=form_data,
+                    files=files_payload,
+                )
+            response.raise_for_status()
+            return response
+
+        except FileNotFoundError:
+            logger.error(f"Error: The file was not found at {file_path}")
+            raise
+        except requests.exceptions.RequestException as e:
+            logger.error(f"An error occurred with the request: {e}")
+            return response


### PR DESCRIPTION
## Description

This pull request introduces a proof-of-concept Python client to serve as a working example to give users an alternative way to interact with the OAEBUDT dataspace API.

### How to test it

To test the client interactively, you can run the example commands from `demo.py` within a Python shell.

**1. Prerequisites**

* Make sure you have **Python installed** (recommended version 3.10 or higher).
* Install the **`requests` package**, which is required for making HTTP requests.
    ```bash
    pip install requests
    ```

**2. Run Interactively**

* Open your terminal and navigate into the client's directory:
    ```bash
    cd examples/python-client/
    ```
* Start a Python shell from within this directory:
    ```bash
    python
    ```
* Run through the steps shown in `demo.py`, making sure to replace the placeholder variable values with your actual credentials.